### PR TITLE
TextItem content: Added coersion to string in content setter since 0 numb

### DIFF
--- a/dist/docs/resources/js/paper.js
+++ b/dist/docs/resources/js/paper.js
@@ -5010,7 +5010,7 @@ var TextItem = this.TextItem = Item.extend({
 
 	setContent: function(content) {
 		this._changed(Change.CONTENT);
-		this._content = content;
+		this._content = '' + content;
 	},
 
 	getCharacterStyle: function() {

--- a/dist/paper.js
+++ b/dist/paper.js
@@ -5010,7 +5010,7 @@ var TextItem = this.TextItem = Item.extend({
 
 	setContent: function(content) {
 		this._changed(Change.CONTENT);
-		this._content = content;
+		this._content = '' + content;
 	},
 
 	getCharacterStyle: function() {

--- a/examples/Scripts/PathStructure.html
+++ b/examples/Scripts/PathStructure.html
@@ -15,7 +15,7 @@
 
 	for (var i = 0; i < 3; i++) {
 		var text = new PointText();
-		text.content = '' + i;
+		text.content = i;
 		text.justification = 'center';
 		text.fontSize = 9;
 		segmentTexts.push(text);

--- a/src/text/TextItem.js
+++ b/src/text/TextItem.js
@@ -80,7 +80,7 @@ var TextItem = this.TextItem = Item.extend(/** @lends TextItem# */{
 
 	setContent: function(content) {
 		this._changed(Change.CONTENT);
-		this._content = content;
+		this._content = '' + content;
 	},
 
 	/**


### PR DESCRIPTION
This is a more robust fix than just the PathStructure example that previous to 5637b3e37e4541c4e78180a168107be8282c136f was not displaying the 0 text label as it was using a number for the property setter and later that failed a falsy test in PointText draw().

Another option would be to leave the content as-is (whether number or text or other) and then change the (!this._content) check in PointText draw() to a null/undefined check. That would make the content property more extensible, as its type could be variable even if its expected to be a string.

I chose the above fix for consistency with the documented type of TextItem content (String).
