### PR TITLE
Raster.setTransform(), a candidate for Item.setTransform()

### DIFF
--- a/dist/paper.js
+++ b/dist/paper.js
@@ -2204,7 +2204,6 @@ var Item = this.Item = Base.extend({
 		return this.transform(new Matrix().shear(shearX, shearY,
 				center || this.getPosition()));
 	},
-
 	transform: function(matrix, flags) {
 		var bounds = this._bounds,
 			position = this._position;
@@ -2668,6 +2667,12 @@ var Raster = this.Raster = Item.extend({
 	setData: function(data, point) {
 		point = Point.read(arguments, 1);
 		this.getContext(true).putImageData(data, point.x, point.y);
+	},
+
+	setTransform: function(matrix)
+	{
+	    this.matrix = matrix.clone();
+        this._changed(Change.GEOMETRY);
 	},
 
 	_transform: function(matrix, flags) {

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1435,7 +1435,7 @@ var Item = this.Item = Base.extend(/** @lends Item# */{
 		return this.transform(new Matrix().shear(shearX, shearY,
 				center || this.getPosition()));
 	},
-
+	
 	/**
 	 * Transform the item.
 	 * 

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -365,6 +365,17 @@ var Raster = this.Raster = Item.extend(/** @lends Raster# */{
 		this.getContext(true).putImageData(data, point.x, point.y);
 	},
 
+	/**
+	 * Set the raster's transformation.
+	 * 
+	 * @param {Matrix} matrix
+	 */
+	setTransform: function(matrix)
+	{
+	    this.matrix = matrix.clone();
+        this._changed(Change.GEOMETRY);
+	},
+
 	_transform: function(matrix, flags) {
 		// In order to set the right context transformation when drawing the
 		// raster, simply preconcatenate the internal matrix with the provided


### PR DESCRIPTION
Added new Raster.setTransform() method, which should also exist on other Item subclasses. See https://github.com/paperjs/paper.js/issues/13 for motivation on this.
