### PR TITLE
Example: Stroke Bounds: Added two missing semicolons, example is broken w

### DIFF
--- a/examples/Scripts/StrokeBounds.html
+++ b/examples/Scripts/StrokeBounds.html
@@ -73,11 +73,11 @@
 			path.scale(1.5, new Point(300, 0));
 			var rect = new Path.Rectangle(path.strokeBounds);
 			rect.strokeWidth = 0.25;
-			rect.strokeColor = 'black'
+			rect.strokeColor = 'black';
 			rect.fillColor = null;
 			var rect = new Path.Rectangle(path.bounds);
 			rect.strokeWidth = 0.25;
-			rect.strokeColor = 'red'
+			rect.strokeColor = 'red';
 			rect.fillColor = null;
 		}
 		


### PR DESCRIPTION
Example: Stroke Bounds: Added two missing semicolons, example is broken without them.
