### PR TITLE
Get rid of trailing comma to prevent parser error in IE

### DIFF
--- a/src/browser/DomEvent.js
+++ b/src/browser/DomEvent.js
@@ -84,7 +84,7 @@ var DomEvent = {
 	stop: function(event) {
 		DomEvent.stopPropagation(event);
 		DomEvent.preventDefault(event);
-	},
+	}
 };
 
 DomEvent.requestAnimationFrame = new function() {


### PR DESCRIPTION
I have updated DOMEvent.js to get rid of a trailing comma.  

This was causing closure compiler errors for me in a project where I was minifying paper.js, and this fixes the problem.
