### PR TITLE
Add keycodes for Mac command keys in different browsers.

### DIFF
--- a/src/ui/Key.js
+++ b/src/ui/Key.js
@@ -40,7 +40,9 @@ var Key = this.Key = new function() {
 		39: 'right',
 		40: 'down',
 		46: 'delete',
-		91: 'command'
+		91: 'command',
+		93: 'command', // WebKit right command button
+		224: 'command'  // Gecko command button
 	},
 
 	// Use Base.merge to convert into a Base object, for #toString()


### PR DESCRIPTION
- 224 for firefox
- 93 for the right command key in WebKit browsers.

I build the dist/paper.js, but there were a multitude of other changes. So I am only submitting a change to the src file.
