### PR TITLE
Clipped groups to support clipping of any object

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -414,10 +414,6 @@ var Item = this.Item = Base.extend(/** @lends Item# */{
 		// On-the-fly conversion to boolean:
 		if (this._clipMask != (clipMask = !!clipMask)) {
 			this._clipMask = clipMask;
-			if (clipMask) {
-				this.setFillColor(null);
-				this.setStrokeColor(null);
-			}
 			this._changed(Change.ATTRIBUTE);
 			// Tell the parent the clipping mask has changed
 			if (this._parent)

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -1396,8 +1396,6 @@ var Path = this.Path = PathItem.extend(/** @lends Path# */{
 			if (param.selection) {
 				ctx.stroke();
 				drawHandles(ctx, this._segments);
-			} else if (this._clipMask) {
-				ctx.clip();
 			} else if (!param.compound && (fillColor || strokeColor)) {
 				// If the path is part of a compound path or doesn't have a fill
 				// or stroke, there is no need to continue.


### PR DESCRIPTION
**Re-opened from phantom [request 56](https://github.com/paperjs/paper.js/pull/56)**

Changed implementation of clipped groups to support masking from any object

As `CanvasNode.clip()` does not seem to support clipping to anything other than a path, changed the implementation to instead render to an in-memory canvas, and use `globalCompositeOperation` to achieve the desired effect.

As discussed [on the mailing list](https://groups.google.com/d/topic/paperjs/kKApCRXdDkk/discussion), this allows a shape to be clipped within text for example.
