### PR TITLE
Use break to avoid uncaught exception in View.updateFocus

### DIFF
--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -432,7 +432,7 @@ var View = this.View = Base.extend(Callback, /** @lends View# */{
 				var view = View._views[i];
 				if (view && view.isVisible()) {
 					View._focused = tempFocus = view;
-					throw Base.stop;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
As outer loop (PaperScope.each) has been removed, use `throw Base.stop' will cause uncaught exception.
