### PR TITLE
text positioning fixed

### DIFF
--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -74,7 +74,6 @@ var PointText = this.PointText = TextItem.extend(/** @lends PointText# */{
 		ctx.save();
 		ctx.font = this.getFontSize() + 'px ' + this.getFont();
 		ctx.textAlign = this.getJustification();
-		this._matrix.applyToContext(ctx);
 		var fillColor = this.getFillColor(),
 			strokeColor = this.getStrokeColor(),
 			leading = this.getLeading();


### PR DESCRIPTION
As already described in issue #63, PointText positioning goes wrong. It seems that the matrix is applied twice: By the draw method of PointText.js and Item.js.
Removing the line in PointText does not seem to have any side effects. Note that the unit test `Compare Item#position` for `PointText#clone()` still fails (like in the previous nightly build). I don't have the needed overview on paper.js yet to fix this also...
