### PR TITLE
Path.reverse() should adjust segment indices

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -828,6 +828,8 @@ var Path = this.Path = PathItem.extend(/** @lends Path# */{
 			var handleIn = segment._handleIn;
 			segment._handleIn = segment._handleOut;
 			segment._handleOut = handleIn;
+			// Adjust index
+			segment._index = i;
 		}
 		// Flip clockwise state if it's defined
 		if (this._clockwise !== undefined)

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -265,6 +265,14 @@ test('Path#reverse', function() {
 	equals(path.segments.toString(), '{ point: { x: 100, y: 130 }, handleIn: { x: -16.56854, y: 0 }, handleOut: { x: 16.56854, y: 0 } },{ point: { x: 130, y: 100 }, handleIn: { x: 0, y: 16.56854 }, handleOut: { x: 0, y: -16.56854 } },{ point: { x: 100, y: 70 }, handleIn: { x: 16.56854, y: 0 }, handleOut: { x: -16.56854, y: 0 } },{ point: { x: 70, y: 100 }, handleIn: { x: 0, y: -16.56854 }, handleOut: { x: 0, y: 16.56854 } }');
 });
 
+test('#reverse should adjust segment indices', function() {
+	var path = new Path([[0, 0], [10, 10], [20, 20]]);
+	path.reverse();
+	equals(path.segments[0]._index, 0);
+	equals(path.segments[1]._index, 1);
+	equals(path.segments[2]._index, 2);
+});
+
 test('Path#fullySelected', function() {
 	var path = new Path.Circle([100, 100], 10);
 	path.fullySelected = true;


### PR DESCRIPTION
Hey there,

var p = new paper.Path( [[0, 0], [10, 10]] )
p.reverse()

before...

p.firstSegment.next === null

because...

p.firstSegment._index === 1 instead of 0

after the fix...

p.firstSegment.next is point [0,0]

...assuming I fixed things correctly ;)

Cheers.
