### PR TITLE
Fix for node v0.6.17

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./src/loadNode.js');

--- a/node.js/index.js
+++ b/node.js/index.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 	path = require('path'),
 	// Have HTMLCanvasElement reference Canvas too, so we do not handle browser
 	// and server differently in some places of our code.
-	Canvas = HTMLCanvasElement =require('canvas');
+	Canvas = require('canvas');
 
 __dirname = path.resolve(__dirname, '../src/');
 
@@ -16,6 +16,7 @@ var context = vm.createContext({
 	fs: fs,
 	// Node Canvas library: https://github.com/learnboost/node-canvas
 	Canvas: Canvas,
+	HTMLCanvasElement: Canvas,
 	Image: Canvas.Image,
 	// Copy over global variables:
     console: console,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 	"keywords": ["canvas", "graphic", "graphics", "vector", "paper.js"], 	
 	"repository": "git://github.com/paperjs/paper.js/",
 	"dependencies": {
-		"canvas": "0.7.0"
+		"canvas": ">= 0.7.0"
 	},
-	"engines": { "node": ">= 0.4.0 && < 0.6.0" },
+	"engines": { "node": ">= 0.4.0" },
 	"main": "./node.js/index.js"
 }


### PR DESCRIPTION
I had to make these changes to get paper.js up and running with npm for nodejs 0.6.17
- Update package.json
- Add HTMLCanvasElement to vm scope
