### PR TITLE
Group opacity disregarded in rasterize

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1020,7 +1020,7 @@ var Item = this.Item = Base.extend(Callback, /** @lends Item# */{
 			matrix = new Matrix().scale(scale).translate(-bounds.x, -bounds.y);
 		matrix.applyToContext(ctx);
 		// XXX: Decide how to handle _matrix
-		this.draw(ctx, {});
+		Item.draw(this, ctx, {});
 		var raster = new Raster(canvas);
 		raster.setBounds(bounds);
 		return raster;


### PR DESCRIPTION
Blending mode and opacity settings are lost when rasterizing a group. It's obviously unneccesary for the blending modes, but opacity information can be stored in the rendered bitmap. 

This also provides quite a large performance boost over setting the opacity on the `Raster` object - no need to render to a temporary canvas in each draw cycle. 

The simplest solution I found is to use the static `Item.draw` in the `rasterize` function, which handles these settings. 
