### PR TITLE
Fixed memory leak

### DIFF
--- a/examples/Scripts/Chain.html
+++ b/examples/Scripts/Chain.html
@@ -26,8 +26,8 @@
 			for (var i = 0; i < size - 1; i++) {
 				var nextSegment = segments[i + 1];
 				var position = path.segments[i].point;
-				var angle = (position - nextSegment.point).angle;
-				var vector = new Point({ angle: angle, length: 35 });
+				var vector = position - nextSegment.point;
+				vector.length = 35;
 				nextSegment.point = position - vector;
 			}
 			path.smooth();


### PR DESCRIPTION
The original technique isn't horrible when it happens
once per mouse move but if used once per frame it completely
destroys the browser.

To see the leak in the chrome task manager - furiously move the
mouse and see the top cpu process keep rising in memory usage.
