### PR TITLE
Late load of paperjs should still run paperscripts

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -298,7 +298,13 @@ var PaperScript = this.PaperScript = new function() {
 		}
 	}
 
-	DomEvent.add(window, { load: load });
+	// Catch cases where paperjs is loaded after the browser event has already occurred.
+	if ( document.readyState === "complete" ) {
+		// Handle it asynchronously
+		setTimeout( load );
+	} else {
+		DomEvent.add(window, { load: load });
+	}
 
 	// Produces helpers to e.g. check for both 'canvas' and 'data-paper-canvas'
 	// attributes:


### PR DESCRIPTION
See this problem case http://stackoverflow.com/questions/14110205/dynamically-loading-a-script-changes-its-behaviour/14114337 and note how jquery handle it at https://github.com/jquery/jquery/blob/master/src/core.js#L768
