### PR TITLE
Update getView to handle DOM elements without getAttribute

### DIFF
--- a/src/ui/View.js
+++ b/src/ui/View.js
@@ -530,6 +530,9 @@ var View = this.View = Base.extend(Callback, /** @lends View# */{
 
 	function getView(event) {
 		// Get the view from the current event target.
+		var target = DomEvent.getTarget(event);
+		if (target.getAttribute === undefined)
+			return false;
 		return View._viewsById[DomEvent.getTarget(event).getAttribute('id')];
 	}
 


### PR DESCRIPTION
In an application I'm building, we render some SVG documents in the DOM using the `<svg>` tag.  We're using paper.js to do other work on the page unrelated to those SVGs.

However, paper.js is checking mousemove events, and these fail in Chrome when you mouseover an SVG, with the following error:

```
Uncaught TypeError: Object #<SVGElementInstance> has no method 'getAttribute' paperjs-0.22.js:6798 mousemove
```

The attached commit modifies getView to check if a DOM element has a getAttribute method before attempting to call getAttribute.

If this isn't your preferred approach to the problem, let me know and I'm happy to take a different one!
