### PR TITLE
Fix project.clear()

### DIFF
--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -84,7 +84,7 @@ var Project = PaperScopeItem.extend(/** @lends Project# */{
 	// DOCS: Project#clear()
 
 	clear: function() {
-		for (var i = 0; i < this.layers.length; i++)
+		for (var i = this.layers.length - 1; i >= 0; i--)
 			this.layers[i].remove();
 		this.symbols = [];
 	},

--- a/test/tests/Project.js
+++ b/test/tests/Project.js
@@ -24,3 +24,12 @@ test('activate()', function() {
 		return secondDoc.activeLayer.children.length == 0;
 	}, true);
 });
+
+test('clear()', function() {
+    var project = new Project();
+    new Layer();
+    new Layer();
+    equals(project.layers.length, 3);
+    project.clear();
+    equals(project.layers.length, 0);
+});


### PR DESCRIPTION
Because of the way Base.splice() works with reindexing the lists, if the layers list is run from 0 through the end, it will only process half the list (because the reindexing changes the indexes that exist in the list). Instead, we can just run through it from the end to the beginning.

Also added a test to double-check this works.
