### PR TITLE
Fix importSVG

### DIFF
--- a/src/dom/node.js
+++ b/src/dom/node.js
@@ -53,7 +53,7 @@ function DOMParser() {
 }
 
 DOMParser.prototype.parseFromString = function(string, contenType) {
-	var div = doc.createElement('div');
+	var div = document.createElement('div');
 	div.innerHTML = string;
 	return div.firstChild;
 };


### PR DESCRIPTION
importSVG is broken - got an error when running 'node SVGImport.js' example ('doc is not defined').
seems to have been broken by latest commit, 'doc' to 'document' rename.
