### PR TITLE
Use named module amd syntax

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -27,7 +27,7 @@ paper = new (PaperScope.inject(Base.merge(Base.exports, {
 
 // Support AMD (e.g. require.js)
 if (typeof define === 'function' && define.amd)
-	define(paper);
+	define('paper', [], function() { return paper; });
 
 /*#*/ } else if (options.node) {
 


### PR DESCRIPTION
Simply calling `define(paper)` in a r.js build throws a deps error. Switching to the named module syntax fixes this issue.

Libraries such as jQuery and Hammer.js use this syntax for AMD support.
