### PR TITLE
Fix to #263: _children undefined inside call to myShape.isEmpty().

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -774,7 +774,7 @@ var Item = Base.extend(Callback, /** @lends Item# */{
 	 * @type Boolean
 	 */
 	isEmpty: function() {
-		return this._children.length == 0;
+		return !this._children || this._children.length == 0;
 	}
 }, Base.each(['getBounds', 'getStrokeBounds', 'getHandleBounds', 'getRoughBounds'],
 	function(name) {


### PR DESCRIPTION
Fixes issue #263 by changing isEmpty to handle the case when `_children` is undefined.
