### PR TITLE
Override default isEmpty method for Shape

### DIFF
--- a/src/item/Shape.js
+++ b/src/item/Shape.js
@@ -21,6 +21,16 @@ var Shape = Item.extend(/** @lends Shape# */{
 	_class: 'Shape',
 	_transformContent: false,
 
+	/**
+	 * Assumed that shape can never be empty.
+	 * Fixes (new Group([new Shape.Rectangle(...)])).bounds throwing ReferenceError.
+	 * 
+	 * @returns bool
+	 */
+	isEmpty: function() {
+		return false;
+	},
+
 	initialize: function Shape(type, point, size, props) {
 		this._initialize(props, point);
 		this._type = type;


### PR DESCRIPTION
Fixes (new Group([new Shape.Rectangle(...)])).bounds throwing ReferenceError when using Item's isEmpty
