### PR TITLE
Fix bug with several paperscripts loading remotely

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -313,11 +313,12 @@ paper.PaperScope.prototype.PaperScript = (function(root) {
 							|| new PaperScope(script).setup(canvas),
 					src = script.src;
 				if (src) {
-					// If we're loading from a source, request that first and
-					// then run later.
-					paper.Http.request('get', src, function(code) {
-						evaluate(code, scope);
-					});
+					(function() {
+			                        const local_scope = scope;
+			                        paper.Http.request('get', src, function(code) {
+			                              evaluate(code, local_scope);
+			                	});
+		                        })();
 				} else {
 					// We can simply get the code form the script tag.
 					evaluate(script.innerHTML, scope);


### PR DESCRIPTION
The thing is when using multiple remote scripts, closure that evaluates script after http requestcomplete tries to access mutable variable "scope". The result is both paper-scripts will be rendered into latest scope/canvas, in example below it will be "card-back".

<script src="{{ STATIC_PREFIX }}js/paper-full.js" type="text/javascript"></script>

<script src="{{ STATIC_PREFIX }}js/postcard_front.js" type="text/paperscript" canvas="card-front"></script>

<script src="{{ STATIC_PREFIX }}js/postcard_back.js" type="text/paperscript" canvas="card-back"></script>
