### PR TITLE
Fix crashing stroke bounds

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2673,10 +2673,10 @@ statics: {
 		var point = segment._point,
 			loc = segment.getLocation(),
 			normal;
-        if (!loc) {
-            return;
-        }
-        normal = loc.getNormal().normalize(radius);
+		if (!loc) {
+			return;
+		}
+		normal = loc.getNormal().normalize(radius);
 		if (area) {
 			addPoint(point.subtract(normal));
 			addPoint(point.add(normal));

--- a/test/tests/Path_Bounds.js
+++ b/test/tests/Path_Bounds.js
@@ -75,11 +75,11 @@ test('path.strokeBounds on path without stroke', function() {
 });
 
 test('path.strokeBounds on path with single segment and stroke color', function() {
-    var path = new Path([
-        new Segment(new Point(121, 334), new Point(-19, 38), new Point(30.7666015625, -61.53369140625))
-    ]);
-    path.style.strokeColor = 'black';
-    compareRectangles(path.strokeBounds, { x: 121, y: 334, width: 0, height: 0 });
+	var path = new Path([
+		new Segment(new Point(121, 334), new Point(-19, 38), new Point(30.7666015625, -61.53369140625))
+	]);
+	path.style.strokeColor = 'black';
+	compareRectangles(path.strokeBounds, { x: 121, y: 334, width: 0, height: 0 });
 });
 
 test('path.bounds & path.strokeBounds with stroke styles', function() {


### PR DESCRIPTION
Test and fix for crashing path.strokeBounds when path has only one segment and strokeColor is set. Because there is only one segment, getLocation returns null and getNormal cannot be called. Paths with a single segment are not drawn and therefore have zero width and height.
