### PR TITLE
Fix a bug that `i++` works as `++i`

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -228,8 +228,9 @@ Base.exports.PaperScript = (function() {
 					if (node.type === 'UpdateExpression') {
 						if (!node.prefix) {
 							var arg = getCode(node.argument);
-							replaceCode(node, arg + ' = _$_(' + arg + ', "'
-									+ node.operator[0] + '", 1)');
+							replaceCode(node, '(function(){this.tmp = ' + arg + ';'
+									+ arg + ' = _$_(' + arg + ', "' + node.operator[0] + '", 1);'
+									+ 'return this.tmp})()');
 						}
 					} else { // AssignmentExpression
 						if (/^.=$/.test(node.operator)


### PR DESCRIPTION
#492
