### PR TITLE
added path preview and esc-key undo to BezierTool

### DIFF
--- a/examples/Tools/BezierTool.html
+++ b/examples/Tools/BezierTool.html
@@ -7,6 +7,7 @@
     <script type="text/javascript" src="../../dist/paper-full.js"></script>
     <script type="text/paperscript" canvas="canvas">
         var path;
+        var nextPoint;
         var types = ['point', 'handleIn', 'handleOut'];
         function findHandle(point) {
             for (var i = 0, l = path.segments.length; i < l; i++) {
@@ -62,11 +63,22 @@
                 if (!currentSegment)
                     currentSegment = path.add(event.point);
                 currentSegment.selected = true;
+                nextPoint = null;
+            }
+        }
+
+        function onMouseMove(event) {
+            if (path) {
+                if (nextPoint) {
+                    path.removeSegment(path.segments.length - 1);
+                }
+                nextPoint = event.point;
+                path.add(nextPoint);
             }
         }
 
         function onMouseDrag(event) {
-            if (mode == 'move' && type == 'point') {
+            if (mode == 'move' && type == 'point' && nextPoint != null) {
                 currentSegment.point = event.point;
             } else if (mode != 'close') {
                 var delta = event.delta.clone();
@@ -74,6 +86,22 @@
                     delta = -delta;
                 currentSegment.handleIn += delta;
                 currentSegment.handleOut -= delta;
+            }
+        }
+
+        function onKeyDown(event) {
+            if (event.key == 'escape' && path) {
+                if (nextPoint && path.segments.length > 2) {
+                    path.removeSegment(path.segments.length - 2);
+                }
+                else if (!nextPoint && path.segments.length > 1) {
+                    path.removeSegment(path.segments.length - 1);
+                }
+                else {
+                    path.removeSegments();
+                    path = null;
+                }
+                return false;
             }
         }
     </script>


### PR DESCRIPTION
Added some features to the BezierTool example:
- path preview: line follows mouse (onMouseMove) to show what would happen if you placed a point -- accomplished with the placeholder nextPoint segment variable
- undo: onKeyDown handles escape key to remove the last point added to path

Learning how this library works and also trying to make this example act more like Illustrator pen tool. Let me know what you think.
