### PR TITLE
First usable version of a canvas-less paperjs

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -40,6 +40,12 @@ then
     rm ../dist/paper-node.js
 fi
 
+if [ -f ../dist/paper-worker.js ]
+then
+    rm ../dist/paper-worker.js
+fi
+
 ./preprocess.sh $MODE ../src/paper.js "-i '../src/constants.js'" ../dist/paper-full.js
 ./preprocess.sh $MODE ../src/paper.js "-o '{ \"paperScript\": false, \"palette\": false }' -i '../src/constants.js'" ../dist/paper-core.js
 ./preprocess.sh $MODE ../src/paper.js "-o '{ \"environment\": \"node\", \"legacy\": false }' -i '../src/constants.js'" ../dist/paper-node.js
+./preprocess.sh $MODE ../src/paper.js "-o '{ \"environment\": \"worker\", \"legacy\": false, \"paperScript\": false, \"palette\": false }' -i '../src/constants.js'" ../dist/paper-worker.js

--- a/src/canvas/CanvasProvider.js
+++ b/src/canvas/CanvasProvider.js
@@ -27,10 +27,12 @@ var CanvasProvider = {
         } else {
 /*#*/ if (__options.environment == 'browser') {
             canvas = document.createElement('canvas');
-/*#*/ } else { // __options.environment != 'browser'
+/*#*/ } else if (__options.environment == 'node') {
             canvas = new Canvas(width, height);
             clear = false; // It's already cleared through constructor.
-/*#*/ } // __options.environment != 'browser'
+/*#*/ } else {
+            return { getContext: function() {} };
+/*#*/ } // __options.environment == 'worker'
         }
         var ctx = canvas.getContext('2d');
         // If they are not the same size, we don't need to clear them

--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -61,6 +61,7 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
         this._id = PaperScope._id++;
         PaperScope._scopes[this._id] = this;
         var proto = PaperScope.prototype;
+/*#*/ if (__options.environment != 'worker') {
         if (!this.support) {
             // Set up paper.support, as an object containing properties that
             // describe the support of various features.
@@ -71,6 +72,7 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             };
             CanvasProvider.release(ctx);
         }
+/*#*/ } // __options.environment != 'worker'
 
 /*#*/ if (__options.environment == 'browser') {
         if (!this.browser) {

--- a/src/export.js
+++ b/src/export.js
@@ -13,11 +13,12 @@
 // First add Base and a couple of other objects that are not automatically
 // exported to exports (Numerical, Key, etc), then inject all exports into
 // PaperScope, and create the initial paper object, all in one statement:
-/*#*/ if (__options.environment == 'browser') {
+/*#*/ if (__options.environment != 'node') {
 
 // NOTE: Do not create local variable `var paper` since it would shield the
 // global one in the whole scope.
 
+/*#*/ if (__options.environment == 'browser') {
 paper = new (PaperScope.inject(Base.exports, {
     // Mark fields as enumerable so PaperScope.inject can pick them up
     enumerable: true,
@@ -25,6 +26,14 @@ paper = new (PaperScope.inject(Base.exports, {
     Numerical: Numerical,
     Key: Key
 }))();
+/*#*/ } else if (__options.environment == 'worker') {
+paper = new (PaperScope.inject(Base.exports, {
+    // Mark fields as enumerable so PaperScope.inject can pick them up
+    enumerable: true,
+    Base: Base,
+    Numerical: Numerical
+}))();
+/*#*/ } // __options.environment == 'worker'
 
 // https://github.com/umdjs/umd
 if (typeof define === 'function' && define.amd) {
@@ -40,7 +49,7 @@ if (typeof define === 'function' && define.amd) {
     module.exports = paper;
 }
 
-/*#*/ } else if (__options.environment == 'node') {
+/*#*/ } else { // __options.environment == 'node'
 
 paper = new (PaperScope.inject(Base.exports, {
     // Mark fields as enumerable so PaperScope.inject can pick them up

--- a/src/paper.js
+++ b/src/paper.js
@@ -127,7 +127,9 @@ var paper = new function(undefined) {
 /*#*/ }
 
 /*#*/ include('canvas/CanvasProvider.js');
-/*#*/ include('canvas/BlendMode.js');
+/*#*/ if (__options.environment != 'worker') {
+/*#*/     include('canvas/BlendMode.js');
+/*#*/ }
 /*#*/ if (__options.version == 'dev') {
 /*#*/     include('canvas/ProxyContext.js');
 /*#*/ }

--- a/src/view/CanvasView.js
+++ b/src/view/CanvasView.js
@@ -33,6 +33,7 @@ var CanvasView = View.extend(/** @lends CanvasView# */{
      */
     initialize: function CanvasView(project, canvas) {
         // Handle canvas argument
+/*#*/ if (__options.environment != 'worker') {
         if (!(canvas instanceof HTMLCanvasElement)) {
             // See if the arguments describe the view size:
             var size = Size.read(arguments);
@@ -43,6 +44,7 @@ var CanvasView = View.extend(/** @lends CanvasView# */{
             canvas = CanvasProvider.getCanvas(size);
         }
         this._context = canvas.getContext('2d');
+/*#*/ } // __options.environment != 'worker'
         // Have Item count installed mouse events.
         this._eventCounters = {};
         this._pixelRatio = 1;

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -107,14 +107,14 @@ var View = Base.extend(Emitter, /** @lends View# */{
             style.top = offset.y + 'px';
             document.body.appendChild(stats);
         }
-/*#*/ } else if (__options.environment == 'node') {
+/*#*/ } else { // __options.environment != 'browser'
         // Sub-classes may set _pixelRatio first
         if (!this._pixelRatio)
             this._pixelRatio = 1;
         // Generate an id for this view
         this._id = 'view-' + View._id++;
         size = new Size(element.width, element.height);
-/*#*/ } // __options.environment == 'node'
+/*#*/ } // __options.environment != 'browser'
         // Keep track of views internally
         View._views.push(this);
         // Link this id to our view


### PR DESCRIPTION
I've added a `worker` option to the environment options that allow to generate a `paper-worker.js` dist file.
This version of paperjs can be initialized without a canvas element and be used inside a WebWorker:

``` js
paper.setup({
    width: 1024,
    height: 1024
});
```

There are numerous methods of the API as well as some objects that become irrelevant/useless without a canvas (such as `.update()` or `.rasterize()`) and using them will probably throw.

The work isn't over, there might be some bugs with parts of the API that I haven't used yet. But I wanted to get your feedback on these environment options. FYI, there's a demo of plumin.js that uses paper-worker.js and is able to build typefaces in a WebWorker: http://byte-foundry.github.io/plumin.js
