### PR TITLE
Export the browser version when using browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"
   ],
   "main": "dist/paper-node.js",
+  "browser": "dist/paper-full.js",
   "files": [
     "AUTHORS.md",
     "dist/paper-node.js",
+    "dist/paper-full.js",
     "examples/Node.js",
     "LICENSE.txt",
     "README.md"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "AUTHORS.md",
     "dist/paper-node.js",
     "dist/paper-full.js",
+    "dist/paper-core.js",
     "examples/Node.js",
     "LICENSE.txt",
     "README.md"


### PR DESCRIPTION
Currently browserify builds in the node version (could you do a patch release svp on npm)

See #461