### PR TITLE
Browser detection: Add Atom shell

### DIFF
--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -82,7 +82,7 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             // here: { chrome: true, webkit: false }, mozilla missing is the
             // only difference to jQuery.browser
             navigator.userAgent.toLowerCase().replace(
-                /(opera|chrome|safari|webkit|firefox|msie|trident)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:([.\d]+))?/g,
+                /(opera|chrome|safari|webkit|firefox|msie|trident|atom)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:([.\d]+))?/g,
                 function(all, n, v1, v2, rv) {
                     // Do not set additional browsers once chrome is detected.
                     if (!browser.chrome) {
@@ -101,6 +101,8 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             );
             if (browser.chrome)
                 delete browser.webkit;
+            if (browser.atom)
+                delete browser.chrome;
         }
 /*#*/ } // __options.environment == 'browser'
     },


### PR DESCRIPTION
I'm developing a Atom plugin that will add a paper.js repl. Eg. you can edit your paper code in one panel and see the visual result in another panel.

Atom is running in an unsual mix of both node and browser environment at the same time. Currently paper.browser detects it as browser.chrome. This enables some feature that aren't helpful in atom, so with this commit I added another browser to paper.browser. 