### PR TITLE
Fix hitTest defaults when options argument is supplied

### DIFF
--- a/src/item/HitResult.js
+++ b/src/item/HitResult.js
@@ -106,6 +106,7 @@ var HitResult = Base.extend(/** @lends HitResult# */{
          * @private
          */
         getOptions: function(options) {
+            options = options || {};
             return new Base({
                 // Type of item, for instanceof check: Group, Layer, Path,
                 // CompoundPath, Shape, Raster, PlacedSymbol, ...
@@ -113,26 +114,26 @@ var HitResult = Base.extend(/** @lends HitResult# */{
                 // Tolerance
                 tolerance: paper.settings.hitTolerance,
                 // Hit the fill of items
-                fill: !options,
+                fill: !options.fill,
                 // Hit the curves of path items, taking into account the stroke
                 // width.
-                stroke: !options,
+                stroke: !options.stroke,
                 // Hit the part of segments that curves pass through, excluding
                 // its segments (Segment#point)
-                segments: !options,
+                segments: !options.segments,
                 // Hit the parts of segments that define the curvature
-                handles: false,
+                handles: !!options.handles,
                 // Only first or last segment hits on path (mutually exclusive
                 // with segments: true)
-                ends: false,
+                ends: !!options.ends,
                 // Hit test the center of the bounds
-                center: false,
+                center: !!options.center,
                 // Hit test the corners and side-centers of the bounding box
-                bounds: false,
+                bounds: !!options.bounds,
                 //  Hit items that are marked as guides
-                guides: false,
+                guides: !!options.guides,
                 // Only hit selected objects
-                selected: false
+                selected: !!options.selected
             }, options);
         }
     }

--- a/src/item/HitResult.js
+++ b/src/item/HitResult.js
@@ -122,18 +122,18 @@ var HitResult = Base.extend(/** @lends HitResult# */{
                 // its segments (Segment#point)
                 segments: !options.segments,
                 // Hit the parts of segments that define the curvature
-                handles: !!options.handles,
+                handles: false,
                 // Only first or last segment hits on path (mutually exclusive
                 // with segments: true)
-                ends: !!options.ends,
+                ends: false,
                 // Hit test the center of the bounds
-                center: !!options.center,
+                center: false,
                 // Hit test the corners and side-centers of the bounding box
-                bounds: !!options.bounds,
+                bounds: false,
                 //  Hit items that are marked as guides
-                guides: !!options.guides,
+                guides: false,
                 // Only hit selected objects
-                selected: !!options.selected
+                selected: false
             }, options);
         }
     }


### PR DESCRIPTION
Options processing for hitTest didn't use default true values for unspecified options when an options object was supplied. For example, if an options object {tolerance: 5} was specified then fill, stroke, and segments would be set to false because there 1) was an options object and 2) those options weren't specified.

The first commit fixes the problem but it made the false defaults more complicated than they needed to be. The second commit goes back to the way the false defaults were.