### PR TITLE
Issue 626: Don't try to iterate a null array

### DIFF
--- a/src/path/PathItem.js
+++ b/src/path/PathItem.js
@@ -163,6 +163,8 @@ var PathItem = Item.extend(/** @lends PathItem# */{
             current = new Point(),
             start = new Point();
 
+        if (!parts) return;
+
         function getCoord(index, coord) {
             var val = +coords[index];
             if (relative)


### PR DESCRIPTION
Whilst using ImportSVG() some SVG files were causing a premature failure resulting in the paper.js code aborting. I tracked it down to a potential null array in setPathData() if the data.match(...) didn't produce any matches.