### PR TITLE
Fix for #638 SVG export creates 'data-paper-data="null"' attribute if item._data is null

### DIFF
--- a/src/svg/SVGExport.js
+++ b/src/svg/SVGExport.js
@@ -387,7 +387,7 @@ new function() {
             if (onExport)
                 node = onExport(item, node, options) || node;
             var data = JSON.stringify(item._data);
-            if (data && data !== '{}' && data != 'null')
+            if (data && data !== '{}' && data !== 'null')
                 node.setAttribute('data-paper-data', data);
         }
         return node && applyStyle(item, node, isRoot);

--- a/src/svg/SVGExport.js
+++ b/src/svg/SVGExport.js
@@ -387,7 +387,7 @@ new function() {
             if (onExport)
                 node = onExport(item, node, options) || node;
             var data = JSON.stringify(item._data);
-            if (data && data  !== '{}')
+            if (data && data !== '{}' && data != 'null')
                 node.setAttribute('data-paper-data', data);
         }
         return node && applyStyle(item, node, isRoot);


### PR DESCRIPTION
Added check for `'null'` after `JSON.stringify()` to prevent unnecessary creation of `data-paper-data="null"` attribute in SVG export.