### PR TITLE
Fixing PlacedSymbol overflow

### DIFF
--- a/src/svg/SVGExport.js
+++ b/src/svg/SVGExport.js
@@ -202,6 +202,7 @@ new function() {
         attrs.y += bounds.y;
         attrs.width = formatter.number(bounds.width);
         attrs.height = formatter.number(bounds.height);
+        attrs.overflow = 'visible';
         return createElement('use', attrs);
     }
 


### PR DESCRIPTION
Initial value for `overflow` of svg elements is `visible`, but for elements that establish new viewports (as with these placed symbols) the value is overridden to `hidden`. A hidden overflow results in clipping of thick strokes, and may have additional consequences (I'm here because I was having trouble with my symbols' strokes).

As detailed in this issue: https://github.com/paperjs/paper.js/issues/642