### PR TITLE
Update to use jsdom v4 (document.defaultView vs. document.parentWindow).

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "canvas": ">= 0.7.0",
-    "jsdom": ">= 0.6.0",
+    "jsdom": "3.1.2",
     "request": "~2.27.0"
   },
   "devDependencies": {

--- a/src/dom/node.js
+++ b/src/dom/node.js
@@ -22,7 +22,7 @@ var jsdom = require('jsdom'),
     // Expose global browser variables and create a document and a window using
     // jsdom, e.g. for import/exportSVG()
     document = jsdom.jsdom('<html><body></body></html>'),
-    window = document.parentWindow,
+    window = document.defaultView,
     navigator = window.navigator,
     HTMLCanvasElement = Canvas,
     Image = Canvas.Image;


### PR DESCRIPTION
jsdom recently dropped support for node.js in favor of io.js and made some [breaking changes](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400).  This fixes the latter issue when using paper.js and io.js v4+