### PR TITLE
Make canvas an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "node": ">= 0.4.0"
   },
   "dependencies": {
-    "canvas": "~1.2.1",
     "jsdom": "~3.1.2",
     "request": "~2.53.0"
+  },
+  "optionalDependencies": {
+    "canvas": "~1.2.1"
   },
   "devDependencies": {
     "uglify-js": "~2.4.16",


### PR DESCRIPTION
canvas should be listed as an optional dependency of paper.js as not everyone is running Paper.js inside node.js

I'm trying to setup Travis-CI for my project and build fails because of this dependency, although I don't need it. I see that I could tweak my Travis config to download a bunch of OS dependencies, but this will slow down Continuous Integration, for no added value.

Please save everyone's time with this simple PR : )