### PR TITLE
include all dist/ files in package.json .files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/paper-node.js",
   "files": [
     "AUTHORS.md",
-    "dist/paper-node.js",
+    "dist/",
     "examples/Node.js",
     "LICENSE.txt",
     "README.md"


### PR DESCRIPTION
npm *can be* and *is often* used as a client-side package manager.
All `dist/` files should be included in the `.files` property of `package.json`.
(again, this is preventing my Travis-CI build to pass)

Thanks : ) 