### PR TITLE
Fix paperscript source from being executed out-of-order

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -450,6 +450,7 @@ Base.exports.PaperScript = (function() {
             var canvasId = PaperScope.getAttribute(script, 'canvas'),
                 canvas = document.getElementById(canvasId),
                 src = script.src,
+                async = PaperScope.hasAttribute(script, 'asyc'),
                 scopeAttribute = 'data-paper-scope';
             if (!canvas)
                 throw new Error('Unable to find canvas with id "'
@@ -462,11 +463,15 @@ Base.exports.PaperScript = (function() {
             // compiling multiple scripts for the same element.
             canvas.setAttribute(scopeAttribute, scope._id);
             if (src) {
-                // If we're loading from a source, request that first and then
-                // run later.
+                // If we're loading from a source, request the source
+                // synchronously to guarantee code is executed in the
+                // same order the script tags appear.
+                // If the async attribute is specified on the script element,
+                // request the source asynchronously and execute as soon as
+                // it is retreived.
                 Http.request('get', src, function(code) {
                     execute(code, scope, src);
-                });
+                }, async);
             } else {
                 // We can simply get the code form the script tag.
                 execute(script.innerHTML, scope, script.baseURI);

--- a/src/net/Http.js
+++ b/src/net/Http.js
@@ -11,11 +11,12 @@
  */
 
 var Http = {
-    request: function(method, url, callback) {
+    request: function(method, url, callback, async) {
         // Code borrowed from Coffee Script and extended:
+        async = (async === undefined) ? true : async;
         var xhr = new (window.ActiveXObject || XMLHttpRequest)(
                     'Microsoft.XMLHTTP');
-        xhr.open(method.toUpperCase(), url, true);
+        xhr.open(method.toUpperCase(), url, async);
         if ('overrideMimeType' in xhr)
             xhr.overrideMimeType('text/plain');
         xhr.onreadystatechange = function() {


### PR DESCRIPTION
It was possible for loadAll to execute paperscript source in a different order from the order the script tags appear in the HTML.  This is due to the script source being retrieved asynchronously in loadScript in the call to Http.request.  This fix retrieves paperscript source synchronously unless the HTML5 async attribute is included on the script element.