### PR TITLE
Change clone() function to fix issue #687

### DIFF
--- a/src/style/Gradient.js
+++ b/src/style/Gradient.js
@@ -124,7 +124,7 @@ var Gradient = Base.extend(/** @lends Gradient# */{
         var stops = [];
         for (var i = 0, l = this._stops.length; i < l; i++)
             stops[i] = this._stops[i].clone();
-        return new Gradient(stops);
+        return new Gradient(stops, this._radial);
     },
 
     /**


### PR DESCRIPTION
As described in issue #687, clone() ignored the 'radial' property. Added the property to the constructor in the clone() function to get the expected behaviour.