### PR TITLE
SVG Import defs first

### DIFF
--- a/src/svg/SVGImport.js
+++ b/src/svg/SVGImport.js
@@ -87,6 +87,14 @@ new function() {
             // items and avoid calling applyAttributes() again.
             project._currentStyle = item._style.clone();
         }
+        // Put defs first, Affinity designer exports defs as last
+        if (isRoot) {
+            var defsNodes = [], otherNodes = [];
+            for (var i = 0, l = nodes.length; i < l; i++) {
+                nodes[i].nodeName.toLowerCase() === 'defs' ? defsNodes.push(nodes[i]) : otherNodes.push(nodes[i]);
+            }
+            nodes = defsNodes.concat(otherNodes);
+        }
         // Collect the children in an array and apply them all at once.
         for (var i = 0, l = nodes.length; i < l; i++) {
             var childNode = nodes[i],


### PR DESCRIPTION
I had problem with importing SVG from Affinity designer, because it exports defs element as last in root level. Other viewers handles that, so its apparently not against the standard. It actually just [recommend](http://www.w3.org/TR/SVG/struct.html) where it should be.

This PR just loads defs first on root level. Likely root level is sufficient. 

Let me know if you think it requires some improvement. Thanks