### PR TITLE
Add support for converting Rasters to dataURL (fix #701)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "node": ">= 0.4.0"
   },
   "dependencies": {
-    "canvas": "~1.2.1",
     "jsdom": "~3.1.2",
     "request": "~2.53.0"
+  },
+  "optionalDependencies": {
+    "canvas": "~1.2.1"
   },
   "devDependencies": {
     "uglify-js": "~2.4.16",

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -462,7 +462,7 @@ var Raster = Item.extend(/** @lends Raster# */{
             return src;
 /*#*/ }
         var canvas = this.getCanvas();
-        return canvas ? canvas.toDataURL() : null;
+        return canvas ? canvas.toDataURL.apply(canvas, arguments) : null;
     },
 
     /**

--- a/src/tool/Tool.js
+++ b/src/tool/Tool.js
@@ -123,8 +123,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
     },
 
     setFixedDistance: function(distance) {
-        this._minDistance = distance;
-        this._maxDistance = distance;
+        this._minDistance = this._maxDistance = distance;
     },
 
     /**


### PR DESCRIPTION
This pr is just a rewrite of #701 which is created by @alecdhuse.
I guess that this would be more compatible with canvas.toDataURL.
If you think #701 is better, i would fix this pr. :)

I also add fix #664, it is not for source code, so i guess that it has little problem about CLA, isnt it?

closes #701 
closes #664 