### PR TITLE
Make "canvas" dependency optional to avoid unnecessary builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "node": ">= 0.4.0"
   },
   "dependencies": {
-    "canvas": "~1.2.1",
     "jsdom": "~3.1.2",
     "request": "~2.53.0"
+  },
+  "optionalDependencies": {
+    "canvas": "~1.2.1"
   },
   "devDependencies": {
     "uglify-js": "~2.4.16",


### PR DESCRIPTION
Fixes #664.