### PR TITLE
crossdomain image

### DIFF
--- a/src/basic/Matrix.js
+++ b/src/basic/Matrix.js
@@ -511,13 +511,12 @@ var Matrix = Base.extend(/** @lends Matrix# */{
 
     _transformCoordinates: function(src, dst, count) {
         var i = 0,
-            j = 0,
             max = 2 * count;
         while (i < max) {
-            var x = src[i++],
-                y = src[i++];
-            dst[j++] = x * this._a + y * this._b + this._tx;
-            dst[j++] = x * this._c + y * this._d + this._ty;
+            var x = src[i],
+                y = src[i+1];
+            dst[i++] = x * this._a + y * this._b + this._tx;
+            dst[i++] = x * this._c + y * this._d + this._ty;
         }
         return dst;
     },

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -342,6 +342,7 @@ var Raster = Item.extend(/** @lends Raster# */{
 /*#*/ if (__options.environment == 'browser') {
             // src can be an URL or a DOM ID to load the image from
             image = document.getElementById(src) || new Image();
+            image.crossOrigin = 'anonymous';
 
         // IE has naturalWidth / Height defined, but width / height set to 0
         // when the image is invisible in the document.

--- a/src/tool/Tool.js
+++ b/src/tool/Tool.js
@@ -123,8 +123,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
     },
 
     setFixedDistance: function(distance) {
-        this._minDistance = distance;
-        this._maxDistance = distance;
+        this._minDistance = this._maxDistance = distance;
     },
 
     /**


### PR DESCRIPTION
As written in #711, it would be necessary to add `image.crossOrigin = 'anonymous';`.
https://developer.mozilla.org/en/docs/Web/HTML/CORS_settings_attributes

close #711