### PR TITLE
setMatrix of item makes more useful

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1130,9 +1130,9 @@ var Item = Base.extend(Emitter, /** @lends Item# */{
         return this._matrix;
     },
 
-    setMatrix: function(matrix) {
+    setMatrix: function() {
         // Use Matrix#initialize to easily copy over values.
-        this._matrix.initialize(matrix);
+        this._matrix.initialize.apply(this._matrix, arguments);
         if (this._applyMatrix) {
             // Directly apply the internal matrix. This will also call
             // _changed() for us.


### PR DESCRIPTION
This pr dose not change current feature, just an addtional feature to `item.setMatrix`.

Additional feature examples:
1. `item.setMatrix()` is same as `item.getMatrix().reset()`
2. `item.setMatrix(2, 0, 0, 2, 5, 5)` is same as `item.getMatrix().initialize(2, 0, 0, 2, 5, 5)`