### PR TITLE
Fixed typo in word 'async'

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -457,7 +457,7 @@ Base.exports.PaperScript = (function() {
             var canvasId = PaperScope.getAttribute(script, 'canvas'),
                 canvas = document.getElementById(canvasId),
                 src = script.src,
-                async = PaperScope.hasAttribute(script, 'asyc'),
+                async = PaperScope.hasAttribute(script, 'async'),
                 scopeAttribute = 'data-paper-scope';
             if (!canvas)
                 throw new Error('Unable to find canvas with id "'


### PR DESCRIPTION
Introduced in https://github.com/hackalyze/paper.js/commit/2ede4f0a6b0e066e37c08784fa6ae5da55bdd9e9

