### PR TITLE
Cross origin cache busting

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -456,7 +456,7 @@ Base.exports.PaperScript = (function() {
             // project is created for it now.
             var canvasId = PaperScope.getAttribute(script, 'canvas'),
                 canvas = document.getElementById(canvasId),
-                src = script.src,
+                src = script.src + '?nocache',
                 async = PaperScope.hasAttribute(script, 'async'),
                 scopeAttribute = 'data-paper-scope';
             if (!canvas)


### PR DESCRIPTION
This is a bit of a weird one, but I wonder if others have encountered it. It also is not necessarily a Paper.js issue so feel free to disregard if it's too specific.

We're serving our JS and PaperScript from Amazon S3 on a different domain, so when our PaperScript file is loaded by XHR, it trips cross origin policies. Luckily we can enable CORS headers for our S3 bucket, which should make everything happy.

Here's where things get weird: when Safari and Chrome see the script tag with `type="text/paperscript"`, they load and cache (but don't execute) the file and its headers. Then when the PaperScript XHR loading fires, the browsers just reach into their cache and pull out the file. However, because the original script loading is not an XHR request, it doesn't include the `Origin` key in its headers and Amazon doesn't include the necessary CORS headers in their response. We get a cross origin violation, but only because the XHR is grabbing the cached file and headers.

The fix is simple but a bit of a hack: include a query string on the XHR to bust the caching.

Hope this helps!