### PR TITLE
Fix to minimize floating point noise

### DIFF
--- a/src/util/Numerical.js
+++ b/src/util/Numerical.js
@@ -207,10 +207,9 @@ var Numerical = new function() {
             } else {
                 // No real roots if D < 0
                 if (D >= -MACHINE_EPSILON) {
-                    D = D < 0 ? 0 : D;
-                    var R = sqrt(D);
-                    // Try to minimise floating point noise.
-                    if (b >= MACHINE_EPSILON && b <= MACHINE_EPSILON) {
+                    var R = sqrt(D < 0 ? 0 : D);
+                    // Try to minimize floating point noise.
+                    if (b >= -MACHINE_EPSILON && b <= MACHINE_EPSILON) {
                         x1 = abs(a) >= abs(c) ? R / a : -c / R;
                         x2 = -x1;
                     } else {


### PR DESCRIPTION
https://github.com/paperjs/paper.js/blob/develop/src/util/Numerical.js#L213 looks strange condition.
I guess that it would be right condition, isn't it?
```diff
- if (b >= MACHINE_EPSILON && b <= MACHINE_EPSILON) {
+ if (b >= -MACHINE_EPSILON && b <= MACHINE_EPSILON) {
```

EDIT: If it is convenient to make a PR to `boolean-fix`, I would create a new PR :) 