### PR TITLE
Faster curve.getNearestParameter when curve has no handles

### DIFF
--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -645,6 +645,20 @@ statics: {
     },
 
     getNearestParameter: function(v, point) {
+        if (!this.hasHandles(v)) {
+            var p1x = v[0], p1y = v[1],
+                p2x = v[6], p2y = v[7],
+                v12x = p2x - p1x, v12y = p2y - p1x,
+                t = ((point.x - p1x) * v12x + (point.y - p1y) * v12y) /
+                      (v12x * v12x + v12y * v12y);
+            if (t <= 0) return 0;
+            if (t >= 1) return 1;
+            if (!t) return 0.5;
+            var roots = [];
+            if (Numerical.solveCubic(2, -3, 0, t, roots, 0, 1) === 1)
+                return roots[0];
+        }
+
         var count = 100,
             minDist = Infinity,
             minT = 0;

--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -650,13 +650,11 @@ statics: {
                 p2x = v[6], p2y = v[7],
                 v12x = p2x - p1x, v12y = p2y - p1x,
                 t = ((point.x - p1x) * v12x + (point.y - p1y) * v12y) /
-                      (v12x * v12x + v12y * v12y);
-            if (t <= 0) return 0;
-            if (t >= 1) return 1;
-            if (!t) return 0.5;
-            var roots = [];
-            if (Numerical.solveCubic(2, -3, 0, t, roots, 0, 1) === 1)
-                return roots[0];
+                      (v12x * v12x + v12y * v12y),
+                epsilon = /*#=*/Numerical.EPSILON;
+            if (t < epsilon) return 0;
+            if (t + epsilon > 1) return 1;
+            return 0.5 - Math.cos(Math.acos(2 * t - 1) / 3 + Math.PI * 4 / 3) || 0.5;
         }
 
         var count = 100,


### PR DESCRIPTION
This pr make curve.getNearestParameter to faster and more precisely, when curve has no handles.
This pr is fixed version of #760.

I made a test case for check the result.
Current develop-branch build version: http://jsfiddle.net/3451fv3c/54/
This PR (294904e) build version: http://jsfiddle.net/3451fv3c/56/