### PR TITLE
Handle exportSVG({ precision: 0 }) correctly

### DIFF
--- a/src/util/Formatter.js
+++ b/src/util/Formatter.js
@@ -20,7 +20,7 @@ var Formatter = Base.extend(/** @lends Formatter# */{
      * @param {Number} [precision=5] the amount of fractional digits
      */
     initialize: function(precision) {
-        this.precision = precision || 5;
+        this.precision = precision == null ? 5 : precision;
         this.multiplier = Math.pow(10, this.precision);
     },
 

--- a/test/tests/SVGExport.js
+++ b/test/tests/SVGExport.js
@@ -103,3 +103,12 @@ test('Export SVG polyline', function() {
     }));
 });
 
+test('Export SVG path defaults to precision 5', function() {
+    var path = new Path('M0.123456789,1.9l0.8,1.1');
+    equals(path.exportSVG({}).getAttribute('d'), 'M0.12346,1.9l0.8,1.1');
+});
+
+test('Export SVG path at precision 0', function() {
+    var path = new Path('M0.123456789,1.9l0.8,1.1');
+    equals(path.exportSVG({ precision: 0 }).getAttribute('d'), 'M0,2l1,1');
+});


### PR DESCRIPTION
At present, `path.exportSVG({ precision: 0 })` actually picks precision 5 – have it only do that when the parameter is omitted / `undefined` / `null`.