### PR TITLE
Issue 815: Cannot add segment to Path after removing last segment

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -417,7 +417,7 @@ var Path = PathItem.extend(/** @lends Path# */{
             var total = this._countCurves(),
                 // If we're adding a new segment to the end of an open path,
                 // we need to step one index down to get its curve.
-                from = index + amount - 1 === total ? index - 1 : index,
+                from = Math.max(index + amount - 1 === total ? index - 1 : index, 0),
                 start = from,
                 to = Math.min(from + amount, total);
             if (segs._curves) {

--- a/test/tests/Path_Curves.js
+++ b/test/tests/Path_Curves.js
@@ -106,7 +106,30 @@ test('Curve list after removing a segment - 2', function() {
         return path.curves.length;
     }, 1, 'After removing the last segment, we should be left with one curve.');
 
-    path.addSegment([3, 3]);
+    equals(function() {
+        return path.segments[1].remove();
+    }, true, 'Removing the paths last segment should be successful.');
+
+    equals(function() {
+        return path.curves.length;
+    }, 0, 'After removing the last segment, we should be left with no curves.');
+
+    equals(function() {
+        return path.segments[0].remove();
+    }, true, 'Removing the final remaining segment should be successful.');
+
+    equals(function() {
+        return path.curves.length;
+    }, 0, 'After removing all segments, we should be left with no curves.');
+
+    path.addSegment([0, 0]);
+    path.addSegment([1, 1]);
+
+    equals(function() {
+        return path.curves.length;
+    }, 1, 'After adding two new segments at the end, we should have one curve again.');
+
+    path.addSegment([2, 2]);
 
     equals(function() {
         return path.curves.length;
@@ -116,7 +139,7 @@ test('Curve list after removing a segment - 2', function() {
         return path.curves[1].segment1 === path.curves[0].segment2;
     }, true, "The newly created curve's first segment needs to be the same as the previous curve's second segment.");
 
-    path.addSegments([[4, 4], [5, 5]]);
+    path.addSegments([[3, 3], [4, 4]]);
 
     equals(function() {
         return path.curves.length;


### PR DESCRIPTION
Fixed an issue where after removing the last segment of a path,
new segments cannot be re-added.

Added new Path Curve test cases to test the difference between
a path with one and no segments (zero curves in both cases), which
catches the bug.