### PR TITLE
Replace atan to atan2 for avoiding NaN

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2836,10 +2836,10 @@ statics: {
         var sin = Math.sin(phi),
             cos = Math.cos(phi),
             tan = Math.tan(phi),
-            tx = -Math.atan(b * tan / a),
-            ty = Math.atan(b / (tan * a));
+            tx = Math.atan2(b * tan, a),
+            ty = Math.atan2(b, tan * a);
         // Due to symetry, we don't need to cycle through pi * n solutions:
-        return [Math.abs(a * Math.cos(tx) * cos - b * Math.sin(tx) * sin),
+        return [Math.abs(a * Math.cos(tx) * cos + b * Math.sin(tx) * sin),
                 Math.abs(b * Math.sin(ty) * cos + a * Math.cos(ty) * sin)];
     },
 


### PR DESCRIPTION
I don't know there are following case, but there are some possibilities that Path._getPenPadding returns `NaN`.
If there are such cases, this pr would fix it.

http://sketch.paperjs.org/#S/q1bKS8xNVbJSCs5OLUnOUNJRSs5PAfGT8/OK83NS9XLy0zUCEksy9OLTU0sCUvMCElNSMvPSNQx0FPJSyxV8E0uKMis0DHUMgBBMampqxuQR0m2IRbcBXDfQFUlFqYnZBfmZeSXFSlbRsbUA