### PR TITLE
Add jshint to travis

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
 	"browser": true,
-    "node": true,
-    "wsh": true,
+	"node": true,
+	"wsh": true,
 	"evil": true,
 	"trailing": false,
 	"smarttabs": false,
@@ -13,8 +13,8 @@
 	"loopfunc": true,
 	"boss": true,
 	"shadow": true,
-    "globals": {
-        "Event": true,
-        "MouseEvent": true
-    }
+	"globals": {
+		"Event": true,
+		"MouseEvent": true
+	}
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - "0.12"
-script: 'npm install -g bower && bower install && cd build && ./minify-components.sh && cd .. && gulp test'
+script: 'npm install -g bower && bower install && cd build && ./minify-components.sh && cd .. && npm run lint && gulp test'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   ],
   "main": "dist/paper-node.js",
   "browser": "dist/paper-full.js",
+  "scripts": {
+    "lint": "jshint src"
+  },
   "files": [
     "AUTHORS.md",
     "dist/",
@@ -35,6 +38,7 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-qunit": "^1.2.1",
+    "jshint": "2.8.x",
     "prepro": "~0.9.1",
     "uglify-js": "~2.4.24"
   },

--- a/src/dom/node.js
+++ b/src/dom/node.js
@@ -13,6 +13,7 @@
 // Node.js emulation layer of browser based environment, based on node-canvas
 // and jsdom.
 
+/*global document:true, window:true, navigator:true, HTMLCanvasElement:true, Image:true */
 var jsdom = require('jsdom'),
     // Node Canvas library: https://github.com/learnboost/node-canvas
     Canvas = require('canvas'),

--- a/src/net/Http.js
+++ b/src/net/Http.js
@@ -14,8 +14,8 @@ var Http = {
     request: function(method, url, callback, async) {
         // Code borrowed from Coffee Script and extended:
         async = (async === undefined) ? true : async;
-        var xhr = new (window.ActiveXObject || XMLHttpRequest)(
-                    'Microsoft.XMLHTTP');
+        var xhrConstructor = window.ActiveXObject || XMLHttpRequest;
+        var xhr = new xhrConstructor('Microsoft.XMLHTTP');
         xhr.open(method.toUpperCase(), url, async);
         if ('overrideMimeType' in xhr)
             xhr.overrideMimeType('text/plain');

--- a/src/path/Path.Constructors.js
+++ b/src/path/Path.Constructors.js
@@ -380,7 +380,7 @@ Path.inject({ statics: new function() {
                 sides = Base.readNamed(arguments, 'sides'),
                 radius = Base.readNamed(arguments, 'radius'),
                 step = 360 / sides,
-                three = !(sides % 3),
+                three = sides % 3 === 0,
                 vector = new Point(0, three ? -radius : radius),
                 offset = three ? -1 : 0.5,
                 segments = new Array(sides);


### PR DESCRIPTION
If you would like to add jshint to travis-ci, this pr would help.
If you don't need it, please close this pr.
Second commit is fix errors which reported in jshint.

When there are errors in jshint, travis-ci reports like https://travis-ci.org/sapics/paper.js/builds/101211455