### PR TITLE
Add jshint to node_modules/.gitignore

### DIFF
--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -3,6 +3,7 @@ canvas
 grunt*
 gulp*
 jsdom
+jshint
 prepro
 qunitjs
 request


### PR DESCRIPTION
I am sorry, I forgot to add jshint to node_modules/.gitignore at #898.