### PR TITLE
Improve performance of _getMonoCurves() by filtering more curves

### DIFF
--- a/src/path/PathItem.Boolean.js
+++ b/src/path/PathItem.Boolean.js
@@ -924,8 +924,10 @@ Path.inject(/** @lends Path# */{
                 y1 = v[3],
                 y2 = v[5],
                 y3 = v[7];
-            if (Curve.isStraight(v)) {
-                // Handling straight curves is easy.
+            if (Curve.isStraight(v) ||
+                y0 >= y1 === y1 >= y2 && y1 >= y2 === y2 >= y3) {
+                // Straight curves and curves with end and control points sorted
+                // in y direction are guaranteed to be monotone in y direction.
                 insertCurve(v);
             } else {
                 // Split the curve at y extrema, to get bezier curves with clear


### PR DESCRIPTION
Curves are always monotone in y direction if the y coordinates of their end points and control points are sorted (yP1 >= yC1 >= yC2 >= yP2 or yP1 <= yC1 <= yC2 <= yP2). Performing this check is very cheap compared to the actual finding of extrema in y direction.

In my test case about 75% of the yet unfiltered curves can be filtered. 