### PR TITLE
Add stroke hit-test option for shape items

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1696,8 +1696,8 @@ var Item = Base.extend(Emitter, /** @lends Item# */{
      *     and its sub-classes: {@values Group, Layer, Path, CompoundPath,
      *     Shape, Raster, PlacedSymbol, PointText, ...}
      * @option options.fill {Boolean} hit-test the fill of items
-     * @option options.stroke {Boolean} hit-test the stroke of path items,
-     *     taking into account the setting of stroke color and width
+     * @option options.stroke {Boolean} hit-test the stroke of path and shape
+     *     items, taking into account the setting of stroke color and width
      * @option options.segments {Boolean} hit-test for {@link Segment#point} of
      *     {@link Path} items
      * @option options.curves {Boolean} hit-test the curves of path items,

--- a/src/item/Shape.js
+++ b/src/item/Shape.js
@@ -343,7 +343,7 @@ new function() { // Scope for _contains() and _hitTestSelf() code.
         _hitTestSelf: function _hitTestSelf(point, options) {
             var hit = false,
                 style = this._style;
-            if (style.hasStroke()) {
+            if (options.stroke && style.hasStroke()) {
                 var type = this._type,
                     radius = this._radius,
                     strokeWidth = style.getStrokeWidth(),


### PR DESCRIPTION
This is just a personal proposal.
It looks natural for me to make hitTest options.stroke activate for `shape` items.

It might be better to add `options.shapeStroke` whose default is true, to avoid making differences of result of hitTest.