### PR TITLE
Fix path.arcTo error

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2524,7 +2524,8 @@ new function() { // PostScript-style drawing commands
                 var radius = Size.read(arguments);
                 // If rx = 0 or ry = 0 then this arc is treated as a
                 // straight line joining the endpoints.
-                if (radius.isZero())
+                if (Numerical.isZero(radius.width)
+                    || Numerical.isZero(radius.height))
                     return this.lineTo(to);
                 // See for an explanation of the following calculations:
                 // http://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes


### PR DESCRIPTION
This pr fix path.arcTo error, one of the error case is pointed in #930.

For more safety, following fix might be necessary, at https://github.com/paperjs/paper.js/blob/develop/src/path/Path.js#L2572, 
But, I am not sure that following fix is necessary or not.
```diff
  vector = from.subtract(center);
+ if (vector) {
    extent = vector.getDirectedAngle(to.subtract(center));
    var centerSide = line.getSide(center);
    if (centerSide === 0) {
        // If the center is lying on the line, we might have gotten
        // the wrong sign for extent above. Use the sign of the side
        // of the through point.
        extent = throughSide * Math.abs(extent);
    } else if (throughSide === centerSide) {
        // If the center is on the same side of the line (from, to)
        // as the through point, we're extending bellow 180 degrees
        // and need to adapt extent.
        extent += extent < 0 ? 360 : -360;
    }
+ } else {
+   return this.lineTo(to);
+ }
```