### PR TITLE
Fix for #960 - Shortcut Curve.evaluate() for t === 1

### DIFF
--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -1338,8 +1338,8 @@ new function() { // Scope for methods that require private functions
         if (type === 0) {
             // type === 0: getPoint()
             // Calculate the curve point at parameter value t
-            x = ((ax * t + bx) * t + cx) * t + p1x;
-            y = ((ay * t + by) * t + cy) * t + p1y;
+            x = t === 1 ? p2x : ((ax * t + bx) * t + cx) * t + p1x;
+            y = t === 1 ? p2y : ((ay * t + by) * t + cy) * t + p1y;
         } else {
             // type === 1: getTangent()
             // type === 2: getNormal()


### PR DESCRIPTION
Shortcut Curve.evaluate() for t === 1 to avoid imprecision.