### PR TITLE
Fix #974 - Keep empty clip mask in SVG export

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -110,7 +110,7 @@ new function() {
         var segments = item._segments,
             type,
             attrs = getTransform(item._matrix);
-        if (segments.length === 0)
+        if (segments.length === 0 && !item.isClipMask())
             return null;
         if (matchShapes && !item.hasHandles()) {
             if (segments.length >= 3) {


### PR DESCRIPTION
A path should be exported in SVG if it serves as a clip mask, otherwise all items in the clip group that were hidden by clipping in paper.js become visible in the SVG. This fixes issue #974.