### PR TITLE
paper.PaperScript is undefined in paper-core.js.

### DIFF
--- a/src/node/extend.js
+++ b/src/node/extend.js
@@ -18,12 +18,14 @@ module.exports = function(paper) {
         var sourceMapSupprt = 'require("source-map-support").install(paper.PaperScript.sourceMapSupport);\n',
             sourceMaps = {};
 
-        paper.PaperScript.sourceMapSupport = {
-            retrieveSourceMap: function(source) {
-                var map = sourceMaps[source];
-                return map ? { url: source, map: map } : null;
-            }
-        };
+        if ( paper.PaperScript ) {
+            paper.PaperScript.sourceMapSupport = {
+                retrieveSourceMap: function(source) {
+                    var map = sourceMaps[source];
+                    return map ? { url: source, map: map } : null;
+                }
+            };
+        }
 
         // Register the .pjs extension for automatic compilation as PaperScript
         require.extensions['.pjs'] = function(module, filename) {


### PR DESCRIPTION
I got `Cannot set property 'sourceMapSupport' of undefined` errors when testing plumin.js in Node.js
