### PR TITLE
Fix namespaces of exported svg

### DIFF
--- a/src/svg/SvgElement.js
+++ b/src/svg/SvgElement.js
@@ -23,7 +23,9 @@ var SvgElement = new function() {
         // Mapping of attribute names to required namespaces:
         attributeNamespace = {
             href: xlink,
-            xlink: xmlns
+            xlink: xmlns,
+            xmlns: xmlns,
+            'xmlns:xlink': xmlns
         };
 
     function create(tag, attributes, formatter) {

--- a/src/svg/SvgElement.js
+++ b/src/svg/SvgElement.js
@@ -18,8 +18,8 @@
 var SvgElement = new function() {
     // SVG related namespaces
     var svg = 'http://www.w3.org/2000/svg',
-        xmlns = 'http://www.w3.org/2000/xmlns',
-        xlink = 'http://www.w3.org/1999/xlink',
+        xmlns = 'http://www.w3.org/2000/xmlns/',
+        xlink = 'http://www.w3.org/1999/xlink/',
         // Mapping of attribute names to required namespaces:
         attributeNamespace = {
             href: xlink,


### PR DESCRIPTION
Hi there,

this fix address an issue I've had with the `exportSVG` function in Internet Explorer 11 (on Windows 7). The resulting SVG appeared to be corrupted. The problem was that the svg-tag had invalid namespace attributes:

The following result of exportSVG

`<svg` **`xmlns="http://www.w3.org/2000/svg"`** `x="0" y="0" width="870" height="870" version="1.1"` **`xmlns:NS1="" NS1:xmlns:xlink="http://www.w3.org/1999/xlink“`**`>…</svg>`

should have been 

`<svg x="0" y="0" width="870" height="870" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink“>…</svg>`

I found a description of the exact same problem as well as a solution in this [SO](http://stackoverflow.com/questions/19610089/unwanted-namespaces-on-svg-markup-when-using-xmlserializer-in-javascript-with-ie)