### PR TITLE
Call curve._changed at curve.divideAtTime

### DIFF
--- a/src/basic/Point.js
+++ b/src/basic/Point.js
@@ -46,7 +46,7 @@ var Point = Base.extend(/** @lends Point# */{
      * coordinates.
      *
      * @name Point#initialize
-     * @param {array} array
+     * @param {Array} array
      *
      * @example
      * // Creating a point at x: 10, y: 5 using an array of numbers:

--- a/src/node/window.js
+++ b/src/node/window.js
@@ -52,7 +52,7 @@ XMLSerializer.prototype.serializeToString = function(node) {
 function DOMParser() {
 }
 
-DOMParser.prototype.parseFromString = function(string, contenType) {
+DOMParser.prototype.parseFromString = function(string, contentType) {
     // Create a new document, since we're supposed to always return one.
     var doc = document.implementation.createHTMLDocument(''),
         body = doc.body,

--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -506,6 +506,7 @@ var Curve = Base.extend(/** @lends Curve# */{
             } else {
                 // otherwise create it from the result of split
                 this._segment2 = segment;
+                this._changed();
                 res = new Curve(segment, segment2);
             }
         }


### PR DESCRIPTION
When curve dose not relate with path, it is necessary to call `_changed` after curve divided for removing curve cache.