### PR TITLE
Make Numerical.solveQuadratic() optimizable for Chrome V8

### DIFF
--- a/src/util/Numerical.js
+++ b/src/util/Numerical.js
@@ -234,10 +234,8 @@ var Numerical = new function() {
                     // We multiply with a factor to normalize the coefficients.
                     // The factor is just the nearest exponent of 10, big enough
                     // to raise all the coefficients to nearly [-1, +1] range.
-                    var mult = pow(10,
-                            abs(Math.floor(Math.log(gmC) * Math.LOG10E)));
-                    if (!isFinite(mult))
-                        mult = 0;
+                    var mult = gmC === 0 ? 0 : pow(10,
+                        abs(Math.floor(Math.log(gmC) * Math.LOG10E)));
                     a *= mult;
                     b *= mult;
                     c *= mult;


### PR DESCRIPTION
Little change to help Chrome's V( optimize `Numerical.solveQuadratic()`. In my use case this resulted in an overall performance improvement of about 1.5%. For details see #1078