### PR TITLE
Add check of value range in Curve.solveCubic to improve performance

### DIFF
--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -628,8 +628,13 @@ statics: /** @lends Curve */{
         var p1 = v[coord],
             c1 = v[coord + 2],
             c2 = v[coord + 4],
-            p2 = v[coord + 6],
-            c = 3 * (c1 - p1),
+            p2 = v[coord + 6];
+        if (p1 < val && p2 < val && c1 < val && c2 < val
+                || p1 > val && p2 > val && c1 > val && c2 > val) {
+            // If val is outside the curve values, no solution is possible.
+            return 0;
+        }
+        var c = 3 * (c1 - p1),
             b = 3 * (c2 - c1) - c,
             a = p2 - p1 - c - b;
         return Numerical.solveCubic(a, b, c, p1 - val, roots, min, max);


### PR DESCRIPTION
Performance of `Curve.solveCubic()` can be improved by first checking if the specified value is within the curve's value range. If it is outside the range, the expensive call to `Numerical.solveCubic()` is not necessary.