### PR TITLE
Accidental semicolon in var declaration

### DIFF
--- a/src/event/Key.js
+++ b/src/event/Key.js
@@ -45,7 +45,7 @@ var Key = new function() {
         keyMap = {}, // Map for currently pressed keys
         charMap = {}, // key -> char mappings for pressed keys
         metaFixMap, // Keys that will not receive keyup events due to Mac bug
-        downKey; // The key from the keydown event, if it wasn't handled already
+        downKey, // The key from the keydown event, if it wasn't handled already
 
         // Use new Base() to convert into a Base object, for #toString()
         modifiers = new Base({


### PR DESCRIPTION
I think the semicolon should be a comma, because `modifiers` is not declared anywhere else.