### PR TITLE
Set layer._parent in insertLayer

### DIFF
--- a/src/item/Project.js
+++ b/src/item/Project.js
@@ -356,6 +356,7 @@ var Project = PaperScopeItem.extend(/** @lends Project# */{
             // as we're doing so when adding it to the new owner below.
             layer._remove(false, true);
             Base.splice(this._children, [layer], index, 0);
+            layer._parent = this;
             layer._setProject(this, true);
             // Set the name again to make sure all name lookup structures
             // are kept in sync.

--- a/test/tests/Layer.js
+++ b/test/tests/Layer.js
@@ -125,3 +125,17 @@ test('addChild / appendBottom / nesting', function() {
             && project.layers[1] == firstLayer;
     }, true);
 });
+
+test('remove', function(){
+    var layer1 = new Layer({name: 'test-layer'});
+    var layer2 = new Layer({name: 'test-layer'});
+    var removeCount = 0;
+    while (project.layers['test-layer']) {
+        project.layers['test-layer'].remove();
+        ++removeCount;
+        if (removeCount > 2) break;
+    }
+    equals(function(){
+        return removeCount;
+    }, 2);
+});


### PR DESCRIPTION
It would be necessary to set layer._parent for layer.owner is still set, if layer._index set to undefined.
https://github.com/paperjs/paper.js/blob/develop/src/item/Item.js#L2552

I guess that it would fix problem found in https://groups.google.com/forum/#!topic/paperjs/rAp0uyj5BcU