### PR TITLE
Fix to remove named layer

### DIFF
--- a/src/core/Emitter.js
+++ b/src/core/Emitter.js
@@ -125,7 +125,7 @@ var Emitter = {
                     if (func)
                         func.call(this, type);
                 }
-        }
+            }
         }
     },
 

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -2549,6 +2549,9 @@ new function() { // Injection scope for hit-test functions shared with project
             project = this._project,
             index = this._index;
         if (owner) {
+            // Handle named children separately from index:
+            if (this._name)
+                this._removeNamed();
             // Handle index separately from owner: There are situations where
             // the item is already removed from its list through Base.splice()
             // and index set to undefined, but the owner is still set,
@@ -2560,9 +2563,6 @@ new function() { // Injection scope for hit-test functions shared with project
                             || this.getPreviousSibling();
                 Base.splice(owner._children, null, index, 1);
             }
-            // Handle named children separately from index:
-            if (this._name)
-                this._removeNamed();
             this._installEvents(false);
             // Notify self of the insertion change. We only need this
             // notification if we're tracking changes for now.

--- a/test/tests/Layer.js
+++ b/test/tests/Layer.js
@@ -125,3 +125,17 @@ test('addChild / appendBottom / nesting', function() {
             && project.layers[1] == firstLayer;
     }, true);
 });
+
+test('remove', function(){
+    var layer1 = new Layer({name: 'test-layer'});
+    var layer2 = new Layer({name: 'test-layer'});
+    var removeCount = 0;
+    while (project.layers['test-layer']) {
+        project.layers['test-layer'].remove();
+        ++removeCount;
+        if (removeCount > 2) break;
+    }
+    equals(function(){
+        return removeCount;
+    }, 2);
+});


### PR DESCRIPTION
When layer is a child of project, layer._index is undefined means layer.owner is undefined.
Thus, it would be better to execute layer._removeNamed before layer._index set to undefined.

It would be fix https://groups.google.com/forum/#!topic/paperjs/rAp0uyj5BcU and http://sketch.paperjs.org/#S/jZAxb4MwEIX/iuUFo1DL7kjVLl07NSNmcJ1LcGLukHETVYj/XgNRtkq97d373j3pJo62B17z/QWS63jFHR0WfbWRBfsDUbNXhnBjH4sQ04LXrFitJ13MpcEH+vwv1Cfo7+C+swPIT3DJ4imAaFSl2qrRqtKqzfiCyqMP4Z0CxRwqIhyK7Yyjb0x5pQzeOp/DQ6RzviTXvrF59LblZJDl+ROQEXq6gig3zhGOFEAGOondbu25O/4otto3plXJviLYy4vB2WB+3KoG8phGXjft/As=

This PR also avoids error in #1132.