### PR TITLE
Use correct value for y 45 degree tangent

### DIFF
--- a/src/path/PathItem.Boolean.js
+++ b/src/path/PathItem.Boolean.js
@@ -611,10 +611,9 @@ PathItem.inject(new function() {
                     // Determine the direction in which to check the winding
                     // from the point (horizontal or vertical), based on the
                     // curve's direction at that point. If the tangent is less
-                    // than 45° (y of tangent < sqrt(0.5)), cast the ray
-                    // vertically, otherwise horizontally.
-                    dir = abs(curve.getTangentAtTime(t).normalize().y) < 0.7071
-                            ? 1 : 0;
+                    // than 45°, cast the ray vertically, else horizontally.
+                    dir = abs(curve.getTangentAtTime(t).normalize().y) 
+                            < Math.SQRT1_2 ? 1 : 0;
                 if (parent instanceof CompoundPath)
                     path = parent;
                 // While subtracting, we need to omit this curve if it is

--- a/src/path/PathItem.Boolean.js
+++ b/src/path/PathItem.Boolean.js
@@ -610,8 +610,10 @@ PathItem.inject(new function() {
                     pt = curve.getPointAtTime(t),
                     // Determine the direction in which to check the winding
                     // from the point (horizontal or vertical), based on the
-                    // curve's direction at that point.
-                    dir = abs(curve.getTangentAtTime(t).normalize().y) < 0.5
+                    // curve's direction at that point. If the tangent is less
+                    // than 45° (y of tangent < sqrt(0.5)), cast the ray
+                    // vertically, otherwise horizontally.
+                    dir = abs(curve.getTangentAtTime(t).normalize().y) < 0.7071
                             ? 1 : 0;
                 if (parent instanceof CompoundPath)
                     path = parent;


### PR DESCRIPTION
I got the pythagoras wrong when I wrote this code. The length of the tangent vector is 1, therefore the y component is sqrt(0.5) for 45°. This will not make any difference, but still we should use the correct value.

![image](https://cloud.githubusercontent.com/assets/2122773/18121025/d38bf5a0-6f62-11e6-9f4a-ba0fd8fa87db.png)
