### PR TITLE
Add try-catch block to handle error on _contains

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1688,7 +1688,11 @@ new function() { // Injection scope for various item event handlers
         }
         // We only implement it here for items with rectangular content,
         // for anything else we need to override #contains()
-        return point.isInside(this.getInternalBounds());
+        try{
+            return point.isInside(this.getInternalBounds());
+        } catch (e){
+            return false;
+        }
     },
 
     // DOCS:


### PR DESCRIPTION
Added a try-catch block to return false by default on a containment check. This is to fix an error thrown when checking mouse over or click on an irregular shaped group.

I encountered an error when adding hover and click events to groups. The error thrown was due to `point` being null.

I saw this comment in the source though:

`// We only implement it here for items with rectangular content,
        // for anything else we need to override #contains()`

So I'm not sure whether there is an existing way to handle this error?

Loving paper! Just finishing up a big project built largely using paper.