### PR TITLE
Simple fix for #1191

### DIFF
--- a/src/path/PathItem.Boolean.js
+++ b/src/path/PathItem.Boolean.js
@@ -1036,6 +1036,11 @@ PathItem.inject(new function() {
                         }
                     }
                 }
+                // _time of intersections may be out of synch. Calling getTime()
+                // on intersections makes sure that _time has correct value.
+                for (var i = 0; i < intersections.length; i++) {
+                    intersections[i].getTime();
+                }
             }
             if (hasCrossings) {
                 // Divide any remaining intersections that are still part of


### PR DESCRIPTION
In PathItem.Boolean.resolveCrossings() call getTime() to ensure _time of intersections has correct value after overlaps are removed.

This may be improved by only runnig through the loop if overlaps have actually been removed.