### PR TITLE
Fix length comparison in Path.compare()

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -1558,7 +1558,7 @@ var Path = PathItem.extend(/** @lends Path# */{
         if (!length1 || !length2) {
             // If one path defines curves and the other doesn't, we can't have
             // matching geometries.
-            return length1 ^ length2;
+            return length1 == length2;
         }
         var v1 = curves1[0].getValues(),
             values2 = [],


### PR DESCRIPTION
As described in #1208 Path.compare() returns a wrong result if one of the paths is empty. This little change fixes the behaviour.