### PR TITLE
Replace nodejs version 5 to 6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - stable
-- '5'
+- '6'
 - '4'
 sudo: false
 env:

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2848,7 +2848,7 @@ statics: {
             if (style.getStrokeJoin() === 'miter')
                 joinRadius = strokeRadius * style.getMiterLimit();
             if (style.getStrokeCap() === 'square')
-                joinRadius = Math.max(joinRadius, strokeRadius * Math.sqrt(2));
+                joinRadius = Math.max(joinRadius, strokeRadius * Math.SQRT2);
             strokePadding = Path._getStrokePadding(strokeRadius, strokeMatrix);
             joinPadding = Path._getStrokePadding(joinRadius, strokeMatrix);
         }

--- a/src/path/PathItem.js
+++ b/src/path/PathItem.js
@@ -770,7 +770,7 @@ var PathItem = Item.extend(/** @lends PathItem# */{
      * @function
      *
      * @param {PathItem} path the path to compare this path's geometry with
-     * @return {Boolean} {@true if two paths describe the shame shape}
+     * @return {Boolean} {@true if two paths describe the same shape}
      */
     compare: function(path) {
         var ok = false;


### PR DESCRIPTION
This PR would not change any features.

Currently, nodejs stable version is v7.
To support  active version, I wish to add v6 to Travis.
I guess that it is not necessary to test in v5.
https://github.com/nodejs/LTS#nodejs-long-term-support-working-group