### PR TITLE
Add Line.getDistance() and use it in Curve.getOverlaps()

### DIFF
--- a/src/basic/Line.js
+++ b/src/basic/Line.js
@@ -182,6 +182,10 @@ var Line = Base.extend(/** @lends Line# */{
             return ccw < 0 ? -1 : ccw > 0 ? 1 : 0;
         },
 
+        getDistance: function(px, py, vx, vy, x, y, asVector) {
+            return Math.abs(Line.getSignedDistance(px, py, vx, vy, x, y, asVector));
+        },
+
         getSignedDistance: function(px, py, vx, vy, x, y, asVector) {
             if (!asVector) {
                 vx -= px;

--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -2203,19 +2203,19 @@ new function() { // Scope for intersection using bezier fat-line clipping
         var flip = getSquaredLineLength(v1) < getSquaredLineLength(v2),
             l1 = flip ? v2 : v1,
             l2 = flip ? v1 : v2,
-            line = new Line(l1[0], l1[1], l1[6], l1[7]);
+            getDistance = Line.getDistance;
         // See if the starting and end point of curve two are very close to the
         // picked line. Note that the curve for the picked line might not
         // actually be a line, so we have to perform more checks after.
-        if (line.getDistance(new Point(l2[0], l2[1])) < geomEpsilon &&
-            line.getDistance(new Point(l2[6], l2[7])) < geomEpsilon) {
+        if (getDistance(l1[0], l1[1], l1[6], l1[7], l2[0], l2[1]) < geomEpsilon &&
+            getDistance(l1[0], l1[1], l1[6], l1[7], l2[6], l2[7]) < geomEpsilon) {
             // If not both curves are straight, check against both of their
             // handles, and treat them as straight if they are very close.
             if (!straightBoth &&
-                line.getDistance(new Point(l1[2], l1[3])) < geomEpsilon &&
-                line.getDistance(new Point(l1[4], l1[5])) < geomEpsilon &&
-                line.getDistance(new Point(l2[2], l2[3])) < geomEpsilon &&
-                line.getDistance(new Point(l2[4], l2[5])) < geomEpsilon) {
+                getDistance(l1[0], l1[1], l1[6], l1[7], l1[2], l1[3]) < geomEpsilon &&
+                getDistance(l1[0], l1[1], l1[6], l1[7], l1[4], l1[5]) < geomEpsilon &&
+                getDistance(l1[0], l1[1], l1[6], l1[7], l2[2], l2[3]) < geomEpsilon &&
+                getDistance(l1[0], l1[1], l1[6], l1[7], l2[4], l2[5]) < geomEpsilon) {
                 straight1 = straight2 = straightBoth = true;
             }
         } else if (straightBoth) {


### PR DESCRIPTION
Added a static function `getDistance()` to line, that simply calls `Line.getSignedDistance()` and returns the absolute value. This makes the `Line` API a bit more symmetrical, which already has the mathod `getDistance` for the `Line` prototype.

In Curve.getOverlaps() we create a new instance of `Line` and at least one instance of `Point` to check if the two curves are overlapping lines. This is done for each pair of curves and the result is false in the vast majority of cases. Since this generates quite a lot of garbage for little effect, so I though it would be nice to implement a way that does the same without producing garbage. Also, the new code is smaller when minified, so this compensates a little bit for the extra code in `Line`.