### PR TITLE
Fix item.transform

### DIFF
--- a/src/basic/Matrix.js
+++ b/src/basic/Matrix.js
@@ -671,7 +671,7 @@ var Matrix = Base.extend(/** @lends Matrix# */{
 
     /**
      * Attempts to decompose the affine transformation described by this matrix
-     * into `scaling`, `rotation` and `shearing`, and returns an object with
+     * into `scaling`, `rotation` and `skewing`, and returns an object with
      * these properties if it succeeded, `null` otherwise.
      *
      * @return {Object} the decomposed matrix, or `null` if decomposition is not

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -473,7 +473,7 @@ new function() { // Injection scope for various item event handlers
      *     light', 'color-dodge', 'color-burn', 'darken', 'lighten',
      *     'difference', 'exclusion', 'hue', 'saturation', 'luminosity',
      *     'color', 'add', 'subtract', 'average', 'pin-light', 'negation',
-     *     'source- over', 'source-in', 'source-out', 'source-atop',
+     *     'source-over', 'source-in', 'source-out', 'source-atop',
      *     'destination-over', 'destination-in', 'destination-out',
      *     'destination-atop', 'lighter', 'darker', 'copy', 'xor'
      * @default 'normal'
@@ -3449,7 +3449,7 @@ new function() { // Injection scope for hit-test functions shared with project
         // and transform the cached _bounds and _position without having to
         // fully recalculate each time.
         var decomp = bounds && matrix && matrix.decompose();
-        if (decomp && !decomp.shearing && decomp.rotation % 90 === 0) {
+        if (decomp && decomp.skewing.isZero() && decomp.rotation % 90 === 0) {
             // Transform the old bound by looping through all the cached bounds
             // in _bounds and transform each.
             for (var key in bounds) {


### PR DESCRIPTION
By the commit https://github.com/paperjs/paper.js/commit/3ee46ffc5c85784a34f99c9d56e8b1e04c038189, decompose.shearing is renamed to decompose.skewing.