### PR TITLE
Fix path constructors

### DIFF
--- a/src/path/Path.Constructors.js
+++ b/src/path/Path.Constructors.js
@@ -28,7 +28,7 @@ Path.inject({ statics: new function() {
         path._closed = closed;
         // Set named arguments at the end, since some depend on geometry to be
         // defined (e.g. #clockwise)
-        return path.set(props);
+        return path.set(props, {insert: true});
     }
 
     function createEllipse(center, radius, args) {

--- a/test/tests/Path_Constructors.js
+++ b/test/tests/Path_Constructors.js
@@ -130,3 +130,8 @@ test('new Path.Line({ from: from, to: to })', function() {
     });
     equals(path.segments.toString(), '{ point: { x: 20, y: 20 } },{ point: { x: 40, y: 40 } }');
 });
+
+test('new Path.Line({insert: false, from:[50, 50], to:[100, 100]})', function() {
+    var path = new Path.Line({insert: false, from:[50, 50], to:[100, 100]});
+    equals(path.insert === false, false);
+});


### PR DESCRIPTION
When we set the option with `{insert: false}` in Path.Constructors initialization, the `path.insert` set to `false`.
It causes some problems, because `path.insert` is the function as http://paperjs.org/reference/path/#insert-index-segment. This PR fix it.

I create the sketch for the description.
http://sketch.paperjs.org/#S/rZE9a8MwEIb/itBiG4xiG7KoeMraobSjneFqnz8S5RROIqWE/PfKcvoBhU4VCKFHOj2vpKskOKHU8uWIvptkLjvbL/MLsGDsfClqQfgmnsBP6jkAoNFgem1JhDawPemmLIo89H2+Qm91UwUkqm82zMbsrLGsRcLYJwHfsoeWWvoUVf8vGhmRkvvCTA7ZazGAcXi3n9kegklB5+cLPsI7soK+302z6dMYKmspjsozkDPgMY3GIluybzais+SsQWXsGCtKtYpEXderK1+v94vHE36WpGW+voCdyafbYNkW2VeAv/eEj3tlhON54U7qZn/7AA==