### PR TITLE
start index can be negative in Path._add() if only one segment has been added to the path

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -419,8 +419,7 @@ var Path = PathItem.extend(/** @lends Path# */{
             var total = this._countCurves(),
                 // If we're adding a new segment to the end of an open path,
                 // we need to step one index down to get its curve.
-                start = index > 0 && index + amount - 1 === total ? index - 1
-                    : index,
+                start = Math.max(index > 0 && index + amount - 1 === total ? index - 1 : index,0),
                 insert = start,
                 end = Math.min(start + amount, total);
             if (segs._curves) {


### PR DESCRIPTION
The following (simplified) code was producing the error : "cannot set property _path of undefined" :
```javascript
path.removeSegments();
path.add(anotherPath.segments[0].point);
```

After a bit of search, it appeared that the `start` index in `_add` was negative, this lead `curves[i]` to be `undefined`

The proposed change should fix this issue.