### PR TITLE
Updates key.js deal with auto-filling from Chrome

### DIFF
--- a/src/event/Key.js
+++ b/src/event/Key.js
@@ -81,7 +81,7 @@ var Key = new function() {
                 // Use short version for arrow keys: ArrowLeft -> Left
                 : /^Arrow[A-Z]/.test(key) ? key.substr(5)
                 // This is far from ideal, but what else can we do?
-                : key === 'Unidentified' ? String.fromCharCode(event.keyCode)
+                : key === 'Unidentified'  || key === undefined ? String.fromCharCode(event.keyCode)
                 : key;
         return keyLookup[key] ||
                 // Hyphenate camel-cased special keys, lower-case normal ones:


### PR DESCRIPTION
This deals with the auto-filling from chrome which registers as an undefined key because of the amount of characters that this enters. 

If you don't have this in this error occurs on text-boxes that are auto-filled

https://www.screencast.com/t/8BdlCBMgY