### PR TITLE
Add note about node.js testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ different one:
   through [Node-Canvas](https://github.com/Automattic/node-canvas) as well as
   SVG importing and exporting through [jsdom](https://github.com/tmpvar/jsdom).
 
+Note: Node.js projects which import paper-jsdom must be unit-tested in a node
+environment.  For example, jest tests which utilize paper-jsdom can use this
+docblock:
+```
+/**
+* @jest-environment node
+*/
+```
+
 In order to install `paper-jsdom-canvas`, you need the [Cairo Graphics
 library](http://cairographics.org/) installed in your system:
 


### PR DESCRIPTION
A note to warn users about testing frameworks which might also use a mocked DOM.  Jest has its own jsdom configured, which won't supply a mock-canvas.  Simple fix for jest; I don't know about others.