### PR TITLE
Add drawSelectionHandles and selectionLineWidth options to paper.settings

### DIFF
--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -52,7 +52,10 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             applyMatrix: true,
             insertItems: true,
             handleSize: 4,
-            hitTolerance: 0
+            hitTolerance: 0,
+            drawSelectionHandles: true,
+            selectionLineWidth: 1
+
         });
         this.project = null;
         this.projects = [];
@@ -131,6 +134,11 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
      *     when drawing selections
      * @option [settings.hitTolerance=0] {Number} the default tolerance for hit-
      *     tests, when no value is specified
+     * @option [settings.drawSelectionHandles=true] {Boolean} controls whether
+     *     selected items should show control points in addition to the selection
+     *     outline
+     * @option [settings.selectionLineWidth=0] {Number} the default line width for
+     *     the selection outline, when no value is specified
      */
 
     /**

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4408,6 +4408,7 @@ new function() { // Injection scope for hit-test functions shared with project
                 half = size / 2;
             ctx.strokeStyle = ctx.fillStyle = color
                     ? color.toCanvasStyle(ctx) : '#009dec';
+            ctx.lineWidth=paper.settings.selectionLineWidth;
             if (itemSelected)
                 this._drawSelected(ctx, mx, selectionItems);
             if (positionSelected) {

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2314,7 +2314,9 @@ new function() { // Scope for drawing
             drawSegments(ctx, this, matrix);
             // Now stroke it and draw its handles:
             ctx.stroke();
-            drawHandles(ctx, this._segments, matrix, paper.settings.handleSize);
+            if (paper.settings.drawSelectionHandles) {
+                drawHandles(ctx, this._segments, matrix, paper.settings.handleSize);
+            }
         }
     };
 },


### PR DESCRIPTION
I'm writing a paint editor for a kids' site. For my project, I need to change the look of selected items. Are you guys open to adding more options to paper.settings to customize the look of the select state? I'm happy to discuss other options.

drawSelectionHandles: Allow this to be set to false to not draw the control points and handles on selected items. They show the blue outline only.

selectionLineWidth: Allows this to be set to > 1 so that the blue outline is more defined.