### PR TITLE
Fix order of operations in order to properly cache position calculation.

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -756,9 +756,9 @@ new function() { // Injection scope for various item event handlers
             // If an pivot point is provided, use it to determine position
             // based on the matrix. Otherwise use the center of the bounds.
             var pivot = this._pivot;
-            position = this._position = pivot
+            position = this._position = (pivot
                     ? this._matrix._transformPoint(pivot)
-                    : this.getBounds().getCenter(true);
+                    : this.getBounds().getCenter(true));
         }
         return new ctor(position.x, position.y, this, 'setPosition');
     },

--- a/test/tests/Item.js
+++ b/test/tests/Item.js
@@ -630,6 +630,15 @@ test('Renaming item', function() {
     }, true);
 });
 
+test('Caching of item#position', function() {
+    var path = new Path.Circle(new Point(50, 50), 50);
+    equals(path.position.toString(), '{ x: 50, y: 50 }',
+            'Uncached value');
+			
+	equals(path.position.toString(), '{ x: 50, y: 50 }',
+            'Cached value');
+});
+
 test('Changing item#position.x', function() {
     var path = new Path.Circle(new Point(50, 50), 50);
     path.position.x += 5;


### PR DESCRIPTION
### Description
In Item#getPosition, we are caching the `this._pivot` value into `this._position` instead of using the result of the ternary operator that uses `this._pivot` as the condition.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [X] New tests added or existing tests modified to cover all changes
  - Added, but cannot be run on windows, so not actually tested.
- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
      and `yarn prettier` has been applied)
  - Unable to run, was not apparent how to do so.
