### PR TITLE
Travis: remove node v7 due to no LTS and add v8 due to active LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
 - stable
-- '7'
+- '8'
 - '6'
 - '4'
 sudo: false


### PR DESCRIPTION
### Description

Remove travis test in node v7 due to no LTS.
Add travis test in node v8 due to active LTS.

https://github.com/nodejs/Release#release-schedule