### PR TITLE
Fix Path.splitAt() documentation example

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@
 - Justin Ridgewell <justinridgewell@gmail.com>
 - Andrew Wagenheim <abwagenheim@gmail.com>
 - Scott Kieronski <baroes0239@gmail.com>
+- Samuel Asensi <asensi.samuel@gmail.com>

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -1012,7 +1012,7 @@ var Path = PathItem.extend(/** @lends Path# */{
      * path.strokeColor = 'black';
      *
      * // Split the path half-way:
-     * var path2 = path.splitAt(path2.length / 2);
+     * var path2 = path.splitAt(path.length / 2);
      *
      * // Give the resulting path a red stroke-color
      * // and move it 20px to the right:


### PR DESCRIPTION
### Description

Hi, I fixed a little bug in Path.splitAt() second example which breaks the online [documentation](http://paperjs.org/reference/path/#splitat-location).


As this is my first contribution, I would like to tell you how much I love your library that I use a lot.
I've seen that you are looking for help to maintain the project and I will have a lot of free time in future months.
So if I can be of any help, I would be delighted to.