### PR TITLE
Fix travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
 - stable
-- '8'
-- '6'
-- '4'
+- 8
+# 6.13 and 6.14 causing unreasonable errors in SymbolDefinition.initialize.
+# https://travis-ci.org/paperjs/paper.js/jobs/434854796
+# To avoid these versions, we specify version to 6.12 as temporary solution.
+# See https://github.com/paperjs/paper.js/issues/1523
+- 6.12
+- 4
 sudo: false
 env:
   matrix:

--- a/test/tests/SvgImport.js
+++ b/test/tests/SvgImport.js
@@ -116,8 +116,7 @@ test('Import SVG polyline', function() {
 
 test('Import SVG Image', function(assert) {
     var done = assert.async();
-    var points = '5,5 45,45 5,45 45,5';
-    var svg = '<?xml version="1.0" encoding="utf-8"?><svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image style="overflow:visible;enable-background:new    ;" width="300" height="67" id="e0" xlink:href="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" transform="matrix(0.2149 0 0 0.2149 304.7706 197.8176)"></image></svg>';
+    var svg = '<?xml version="1.0" encoding="utf-8"?><svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image style="overflow:visible;enable-background:new    ;" width="300" height="67" id="e0" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" transform="matrix(0.2149 0 0 0.2149 304.7706 197.8176)"></image></svg>';
     var imported = paper.project.importSVG(svg);
     var raster = imported.children[0];
     raster.on('load', function() {


### PR DESCRIPTION
### Description

This pr fixed all travis errors.

I cannot find out why node v6.13 and v6.14 cause error in SymbolDefinition.initialize.
To avoid these version, I specify test version to v6.12 as temporary solution.
I will make an issue about it.