### PR TITLE
SVGImport: Support optional arguments in SVG translate and rotate

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -336,7 +336,8 @@ new function() {
                             new Matrix(v[0], v[1], v[2], v[3], v[4], v[5]));
                     break;
                 case 'rotate':
-                    matrix.rotate(v[0], v[1], v[2]);
+                    var v2 = (typeof v[1] === 'number' && typeof v[2] !== 'number') ? 0 : v[2];
+                    matrix.rotate(v[0], v[1], v2);
                     break;
                 case 'translate':
                     var v1 = (typeof v[1] === 'number') ? v[1] : 0;


### PR DESCRIPTION
Replacement for #1488, with a clean commit history.

Orignal:

### Description
Fixes https://github.com/paperjs/paper.js/issues/1487

For SVG import, If second argument is missing in translate, assume that it's zero. Currently it assumes that y matches x if y is missing.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
      and `yarn prettier` has been applied)
