### PR TITLE
Fix #1501 errors with event listeners on mobile

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -23,8 +23,17 @@ var DomEvent = /** @lends DomEvent */{
             for (var type in events) {
                 var func = events[type],
                     parts = type.split(/[\s,]+/g);
-                for (var i = 0, l = parts.length; i < l; i++)
-                    el.addEventListener(parts[i], func, false);
+                for (var i = 0, l = parts.length; i < l; i++) {
+                    var eventName = parts[i];
+                    // For touchstart/touchmove events on document, we need to explicitely
+                    // declare that event is not passive (can be prevented).
+                    // Otherwise chrome browser would ignore event.preventDefault() calls.
+                    // See #1501 and https://www.chromestatus.com/features/5093566007214080
+                    var options = el === document && (eventName === 'touchstart'|| eventName === 'touchmove')
+                                  ? {passive: false}
+                                  : false;
+                    el.addEventListener(eventName, func, options);
+                }
             }
         }
     },

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -1440,7 +1440,11 @@ new function() { // Injection scope for event handling on the browser
             //   which can call `preventDefault()` explicitly or return `false`.
             // - If this is a unhandled mousedown event, but the view or tools
             //   respond to mouseup.
-            if (called && !mouse.move || mouse.down && responds('mouseup'))
+            //
+            // Some events are not cancelable anyway (like during a scroll inertia
+            // on mobile) so trying to prevent default in those case would result
+            // in no effect and an error.
+            if (event.cancelable !== false && (called && !mouse.move || mouse.down && responds('mouseup')))
                 event.preventDefault();
         },
 


### PR DESCRIPTION
### Description

This changes fixes #1501 by explicitely declaring document touchstart and touchmove events as not passive and thus allowing them to be prevented later.
Error was linked to a change in chrome behaviour documented [here](https://www.chromestatus.com/features/5093566007214080). More details on the possible solutions are available [here](https://developers.google.com/web/updates/2017/01/scrolling-intervention).

By investigating this issue, I also discovered another linked bug on mobile when you scroll the page and it is still in scroll inertia. By interacting with the canvas, you can be in a situation where the code tries to call `.preventDefault()` on the event while it is not [cancelable](https://developer.mozilla.org/fr/docs/Web/API/Event/cancelable) and this produces an error.
I fixed this bug in the second commit.

#### Related issues

- Fixes #1501

### Checklist

- [x] Code conforms with the JSHint rules (`npm run jslint` passes)
