### PR TITLE
Fix #1493 Path#add crashes whith 1000000 segments

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -406,8 +406,9 @@ var Path = PathItem.extend(/** @lends Path# */{
         if (append) {
             // Append them all at the end.
             // Use a loop as it is the best way to handle big arrays (see #1493)
-            for (var i = 0; i < segs.length; i++)
+            for (var i = 0, l = segs.length; i < l; i++) {
                 segments.push(segs[i]);
+            }
         } else {
             // Insert somewhere else
             segments.splice.apply(segments, [index, 0].concat(segs));

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -405,9 +405,13 @@ var Path = PathItem.extend(/** @lends Path# */{
         }
         if (append) {
             // Append them all at the end.
-            // Use a loop as it is the best way to handle big arrays (see #1493)
-            for (var i = 0, l = segs.length; i < l; i++) {
-                segments.push(segs[i]);
+            // Use a loop as the best way to handle big arrays (see #1493).
+            // Set future array length before the loop for better performances.
+            var originalLength = segments.length;
+            var offsetLength = segs.length;
+            segments.length += offsetLength;
+            for (var i = 0; i < offsetLength; i++) {
+                segments[originalLength + i] = segs[i];
             }
         } else {
             // Insert somewhere else

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -404,8 +404,10 @@ var Path = PathItem.extend(/** @lends Path# */{
                 this._updateSelection(segment, 0, segment._selection);
         }
         if (append) {
-            // Append them all at the end by using push
-            segments.push.apply(segments, segs);
+            // Append them all at the end.
+            // Use a loop as it is the best way to handle big arrays (see #1493)
+            for (var i = 0; i < segs.length; i++)
+                segments.push(segs[i]);
         } else {
             // Insert somewhere else
             segments.splice.apply(segments, [index, 0].concat(segs));

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -614,9 +614,8 @@ test('Path#arcTo(from, through, to); where from, through and to all share the sa
 
 test('#1493 Path#add with 1000000 segments', function() {
     var path = new Path();
-    for (var i=0; i<1000000; i++)
-    {
-        path.add(new Point(0,0));
+    for (var i = 0; i < 1000000; i++) {
+        path.add(new Point(0, 0));
     }
     path.clone();
     expect(0);

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -611,3 +611,13 @@ test('Path#arcTo(from, through, to); where from, through and to all share the sa
     }
     equals(error != null, true, 'We expect this arcTo() command to throw an error');
 });
+
+test('#1493 Path#add with 1000000 segments', function() {
+    var path = new Path();
+    for (var i=0; i<1000000; i++)
+    {
+        path.add(new Point(0,0));
+    }
+    path.clone();
+    expect(0);
+});


### PR DESCRIPTION
### Description

This change prevent `Maximum call stack exceeded` error by using a loop to add segment instead of passing segments array as argument.

#### Related issues

- Fixes #1493

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jslint` passes)
