### PR TITLE
Fix: selected position is wrongly placed when item is in a group with matrix not applied

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4411,7 +4411,7 @@ new function() { // Injection scope for hit-test functions shared with project
             if (itemSelected)
                 this._drawSelected(ctx, mx, selectionItems);
             if (positionSelected) {
-                var point = this.getPosition(true),
+                var point = mx._transformPoint(this.getPosition(true)),
                     x = point.x,
                     y = point.y;
                 ctx.beginPath();


### PR DESCRIPTION
### Description

I found a bug in position selection when item is in a group with matrix not applied.
It is reproduced in this [sketch](http://sketch.paperjs.org/#S/dZLNbsIwEIRfZZVLgkoD7TEVJyr1hFSpvQGHxV4SF2NHtkNAiHevfwShahspUbzzebTj9TlTuKesyj525FiTjTOmeVhPJsAN9iAc7aEXroFWW+GEVmBJEnPEV2alDmgSMgNFPbyja8q5MExSsXyaTsfgP+v4Hb0EPrDlVkg511IbvyvXBlVN+aBe7b3oTEeDsNGd4vZ//drgn0R4fSZsW1LctwxOA0JtdNemeHt0RhxBaRcgKYZ8CUoB38J/kbLEeomczxsheRF6+CF4l9Miuc5gi9LSnXo7zRkcBPUlI+XI3AFaLXRn6dVgHbZ3igW8oIMHR3AOIPjnl1sEfEEoF90u9/HTSJX1xxLtbKjHwQX+k46uuDlHi+q+O3iA5XT8+BxGeqW+OuvEVjAMdhXkicxvOtN+HXzymCTeFfQTsETgGnS+YoerJSz0RqtanqCVyIjnMUI6Vn85N4ZwFxuzWbVcX74B) (drawn position should be in circle center).
Converting point to global coordinates system fixes the issue.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jslint` passes)
