### PR TITLE
Fix: tainted canvas error is not handled

### DIFF
--- a/src/canvas/BlendMode.js
+++ b/src/canvas/BlendMode.js
@@ -275,11 +275,16 @@ var BlendMode = new function() {
             var process = modes[mode];
             if (!process)
                 return;
-            var dstData = dstContext.getImageData(offset.x, offset.y,
-                    srcCanvas.width, srcCanvas.height),
-                dst = dstData.data,
-                src = srcContext.getImageData(0, 0,
-                    srcCanvas.width, srcCanvas.height).data;
+            var dstData = CanvasView.catchTaintedCanvasError(function() {
+                    return dstContext.getImageData(offset.x, offset.y,
+                        srcCanvas.width, srcCanvas.height);
+                }),
+                src = CanvasView.catchTaintedCanvasError(function() {
+                    return srcContext.getImageData(0, 0,
+                        srcCanvas.width, srcCanvas.height).data;
+                });
+            if (!dstData || !src) return;
+            var dst = dstData.data;
             for (var i = 0, l = dst.length; i < l; i += 4) {
                 sr = src[i];
                 br = dst[i];

--- a/src/view/CanvasView.js
+++ b/src/view/CanvasView.js
@@ -140,5 +140,34 @@ var CanvasView = View.extend(/** @lends CanvasView# */{
             project.draw(ctx, this._matrix, this._pixelRatio);
         this._needsUpdate = false;
         return true;
+    },
+
+    statics: /** @lends CanvasView */{
+        /**
+         * Execute callback catching SecurityError and displaying a specific
+         * warning message. This helps handling tainted canvas errors (#1479).
+         * https://developer.mozilla.org/docs/Web/HTML/CORS_enabled_image
+         * @param callback function to execute
+         * @returns {*} callback return value
+         */
+        catchTaintedCanvasError: function(callback) {
+            try {
+                return callback();
+            } catch (e) {
+                // Only catch security errors.
+                if (e.code !== 18) throw e;
+                // Display a warning pointing to problem cause and solution.
+                console.warn('You are seing this error because you tried to ' +
+                    'access canvas image data after drawing an image from an ' +
+                    'external source.\nYour browser prevent you from doing ' +
+                    'this because of CORS, see detailed explanation: ' +
+                    'https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image' +
+                    '\nYou can circumvent this isue, if the external source of ' +
+                    'the image allows cross origin access, by using ' +
+                    'Raster.crossOrigin property: ' +
+                    'http://paperjs.org/reference/raster/#crossorigin\n' +
+                    'Original error:', e);
+            }
+        }
     }
 });

--- a/test/tests/Raster.js
+++ b/test/tests/Raster.js
@@ -206,3 +206,26 @@ test('Raster#setSmoothing setting does not impact canvas context', function(asse
         done();
     };
 });
+
+test('Tainted canvas error is catched', function(assert) {
+    var done = assert.async();
+    var raster = new Raster('http://assets.paperjs.org/images/marilyn.jpg');
+    raster.onLoad = function() {
+        // remove warnings from tests output
+        var consoleWarn = console.warn;
+        console.warn = function() {};
+
+        // call all methods that produce a tainted canvas error
+        raster.getImageData();
+        raster.getPixel();
+        raster.getAverageColor();
+        raster.toDataURL();
+        raster.exportSVG({asString: true});
+        raster.blendMode = 'negation';
+        raster.view.update();
+
+        console.warn = consoleWarn;
+        done();
+    };
+    expect(0);
+});


### PR DESCRIPTION
### Description

Add an internal method wrapping calls that could produce a tainted canvas error and break script execution.
Error is catched and a warning message is displayed instead.


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1479

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
