### PR TITLE
Fix Path#arcTo() do not pass by through point

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2546,7 +2546,7 @@ new function() { // PostScript-style drawing commands
                 }
                 vector = from.subtract(center);
                 extent = vector.getDirectedAngle(to.subtract(center));
-                var centerSide = line.getSide(center);
+                var centerSide = line.getSide(center, true);
                 if (centerSide === 0) {
                     // If the center is lying on the line, we might have gotten
                     // the wrong sign for extent above. Use the sign of the side

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -628,3 +628,13 @@ test('Path#add() with a lot of segments (#1493)', function() {
     path.clone();
     expect(0);
 });
+
+test('Path#arcTo(through, to) is on through point side (#1477)', function() {
+    var p1 = new Point(16, 21.5);
+    var p2 = new Point(22.5, 15);
+    var p3 = new Point(16.000000000000004, 8.5);
+    var path = new Path();
+    path.add(p1);
+    path.arcTo(p2, p3);
+    equals(true, path.segments[1].point.x > p1.x);
+});


### PR DESCRIPTION
### Description

In very specific case, (from point and to point are near to be vertically aligned) `path.arcTo(through, to)` draws the arc on the wrong side of the circle.
Here is a [Sketch](http://sketch.paperjs.org/#S/lZJRS8MwEMe/SsjLOiih6ayMDF/cqw+Cvjkf0uTGYmsSrmmHjH130866ThDdQSD353+/u4Q7UCvfgQr6VEFQO5pS5XSfdxKJ5+SOWNiTR2dsSPhtSnLOivlqgxs7GPILQ56zIiV8alj8ILDsIm5SshyBY41ENRbJsEsODdSgAmhBArZwPJmjiUmtE88nOapnl/g8jW3PyBHE1gZVDcmhF0kMBTYAivjKdJRQatM2gmSMF9/i1tT12tUOxaysW5j1+tcUf7Pzf7MR9HXoxRVjS1VN4f3x6N7ivzKpgungQX4AMu8aE4yz8f87A3t26rX6zb414d61VjfJ4C6HO2uUjPNmbDk/N4t7VSLIyvdr0FDx8nr8BA==) reproducing the issue.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1477

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
