### PR TITLE
Fix item selected position with matrix not applied

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4423,7 +4423,9 @@ new function() { // Injection scope for hit-test functions shared with project
             if (itemSelected)
                 this._drawSelected(ctx, mx, selectionItems);
             if (positionSelected) {
-                var point = mx._transformPoint(this.getPosition(true)),
+                // Get position in global coordinates system
+                var pos = this.getPosition(true),
+                    point = this.parent ? this.parent.localToGlobal(pos) : pos,
                     x = point.x,
                     y = point.y;
                 ctx.beginPath();


### PR DESCRIPTION
### Description

Make sure selected position is drawn in global coordinates system
whether item is in a group or not and whether matrix is applied or not.
Correct a bug introduced in 34679614c0db77387c72fb50e35daac6882e941e.


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
