### PR TITLE
Fix bounds error with nested empty items

### DIFF
--- a/test/tests/Group.js
+++ b/test/tests/Group.js
@@ -134,4 +134,19 @@ test('group.addChildren()', function() {
     group.addChildren(children);
     equals(group.children.length, 2,
             'adding the same item twice should only add it once.');
-})
+});
+
+test('Group#isEmpty(recursive)', function() {
+    var group = new Group();
+    equals(true, group.isEmpty());
+    equals(true, group.isEmpty(true));
+    var group = new Group(new Group());
+    equals(false, group.isEmpty());
+    equals(true, group.isEmpty(true));
+    var group = new Group(new Path());
+    equals(false, group.isEmpty());
+    equals(true, group.isEmpty(true));
+    var group = new Group(new PointText());
+    equals(false, group.isEmpty());
+    equals(true, group.isEmpty(true));
+});

--- a/test/tests/Layer.js
+++ b/test/tests/Layer.js
@@ -139,3 +139,9 @@ test('#remove() with named layers', function(){
     equals(removeCount, 2,
             'project.layers[name].remove(); should be called twice');
 });
+
+test('#bounds with nested empty items', function() {
+    var item = new Path.Rectangle(new Point(10,10), new Size(10));
+    new Group(new Group());
+    equals(item.bounds, project.activeLayer.bounds);
+});


### PR DESCRIPTION
### Description

- add an optional parameter to `Item#isEmpty()` allowing to check
emptiness recursively
- ignore all recursively empty items in bounds calculation

Bug is reproduced in this [Sketch](http://sketch.paperjs.org/#S/fZE/b8MgEMW/yokltmSRZHXVKUOXDpU6NhkIXGsazFkHthVF+e4F/1G6tBt39/i9x3ETXrUoavF+wagbUQlNJtfbLRhWI2jL2uGRj35QvFTwDB5HeFOxkYepU9w0+ohcT32yPha7CnZlBayM7UO9T+Wnde5AjriGDaPZ3MunzJ2Z8ky9N0EGdKgjmuQRucdJsWbxGPIE2y5e4Yup70IeZ8+XXBWPUzmzl9stDQhOXZEhEgw2yea8ed4xfSdLqXS0A75mlewo2GjJpxRZLWf1GiY0NC64OfVfmH/etKB+UzK3dwZalX5iXfXDIP3NmVFdurzeIOqP0/0H) where layer bounds should match circle bounds.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1467

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
