### PR TITLE
Issue 1459 add name and data to segment

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -222,11 +222,11 @@ var Path = PathItem.extend(/** @lends Path# */{
      * @type Segment
      */
     getSegmentByName: function(name) {
-        var segments = this._segments.filter(s => s._name == name);
+        var segments = this._segments.filter(function(s){ return s._name == name; });
         if(segments.length == 0)
             throw new Error(
                 'Segment with name \''+name+'\' not found in the path.');
-        return this._segments.filter(s => s._name == name)[0];
+        return this._segments.filter(function(s){ return s._name == name; })[0];
     },
 
     /**
@@ -236,25 +236,25 @@ var Path = PathItem.extend(/** @lends Path# */{
      * @type Segment[]
      */
     getSegmentsByData: function(options) {
-        if(options !== undefined && typeof options === 'object'){
-            function matchObject(obj1, obj2) {
-                for (var i in obj1) {
-                    if (obj1.hasOwnProperty(i)) {
-                        var val1 = obj1[i],
-                            val2 = obj2[i];
-                        if (Base.isPlainObject(val1) && Base.isPlainObject(val2)) {
-                            if (!matchObject(val1, val2))
-                                return false;
-                        } else if (!Base.equals(val1, val2)) {
+        function matchObject(obj1, obj2) {
+            for (var i in obj1) {
+                if (obj1.hasOwnProperty(i)) {
+                    var val1 = obj1[i],
+                        val2 = obj2[i];
+                    if (Base.isPlainObject(val1) && Base.isPlainObject(val2)) {
+                        if (!matchObject(val1, val2))
                             return false;
-                        }
+                    } else if (!Base.equals(val1, val2)) {
+                        return false;
                     }
                 }
-                return true;
             }
+            return true;
+        }
 
+        if(options !== undefined && typeof options === 'object'){
             var matchedSegments = [];
-            this._segments.forEach(segment => {
+            this._segments.forEach(function(segment){
                 if(matchObject(options, segment.data)){
                     matchedSegments.push(segment);
                 }
@@ -431,11 +431,12 @@ var Path = PathItem.extend(/** @lends Path# */{
      * the segments list automatically.
      */
     _add: function(segs, index) {
+        var segments = this._segments;
         // Make sure all added segments have unique names. 
         // And prevent adding a segment with a name that already exists in the path.
-        segs = segs.filter((obj, pos, arr) => {
-            if(obj.name === '' || obj.name == null || arr.map(s => s.name).indexOf(obj.name) === pos &&
-                    this._segments.map(s => s.name).indexOf(obj.name) < 0)
+        segs = segs.filter(function(obj, pos, arr){
+            if(obj.name === '' || obj.name == null || arr.map(function(s){return s.name;}).indexOf(obj.name) === pos &&
+                segments.map(function(s){return s.name;}).indexOf(obj.name) < 0)
                 return true;
             else
                 throw new Error(
@@ -443,8 +444,7 @@ var Path = PathItem.extend(/** @lends Path# */{
         });
         
         // Local short-cuts:
-        var segments = this._segments,
-            curves = this._curves,
+        var curves = this._curves,
             amount = segs.length,
             append = index == null,
             index = append ? segments.length : index;

--- a/src/path/Segment.js
+++ b/src/path/Segment.js
@@ -266,7 +266,7 @@ var Segment = Base.extend(/** @lends Segment# */{
     },
 
     setName: function(name) {
-        if(this._path && this._path.segments.filter(s => (s.name == name && name != '')).length > 0)
+        if(this._path && this._path.segments.filter(function(s){ return (s.name == name && name != '');}).length > 0)
             throw new Error(
                 'There is already a segment with this name in the path.');
         this._name = name || undefined;

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -620,3 +620,58 @@ test('Path#add() with a lot of segments (#1493)', function() {
     path.clone();
     expect(0);
 });
+
+test('Path#add(); add two segments with the same name', function() {
+    var path = new Path();
+    var segment1 = new Segment({
+        point: [50, 50],
+        name: 'topLeftCorner'
+    }); 
+    var segment2 = new Segment({
+        point: [100, 100],
+        name: 'topLeftCorner'
+    }); 
+    var error = null;
+    try {
+        path.add(segment1, segment2);
+    } catch (e) {
+        error = e;
+    }
+    equals(error != null, true, 'We expect this add() command to throw an error');
+});
+
+test('Path#getSegmentByName();', function() {
+    var path = new Path();
+    var segment = new Segment({
+        point: [50, 50],
+        name: 'topLeftCorner'
+    }); 
+    path.add(segment);
+
+    var error = null;
+    try {
+        path.getSegmentByName('test');
+    } catch (e) {
+        error = e;
+    }
+    equals(error != null, true, 'We expect this getSegmentByName() command to throw an error');
+
+    equals(function() {
+        return path.getSegmentByName('topLeftCorner') == segment;
+    }, 1, 'Getting the segment by name should give us the same segemnt');
+});
+
+test('Path#getSegmentsByData();', function() {
+    var path = new Path();
+    var segment = new Segment({
+        point: [50, 50],
+        data: {
+            corner: true
+        }
+    }); 
+    path.add(segment);
+
+    equals(function() {
+        return path.getSegmentsByData({corner: true})[0] == segment;
+    }, 1, 'Getting the segment by data should give us the same segemnt');
+});

--- a/test/tests/Segment.js
+++ b/test/tests/Segment.js
@@ -37,6 +37,16 @@ test('new Segment(object)', function() {
     equals(segment.toString(), '{ point: { x: 10, y: 10 }, handleIn: { x: 5, y: 5 }, handleOut: { x: 15, y: 15 } }');
 });
 
+test('new Segment(object) with name', function() {
+    var segment = new Segment({ point: { x: 10, y: 10 }, handleIn: { x: 5, y: 5 }, handleOut: { x: 15, y: 15 }, name: "test" });
+    equals(segment.name, 'test');
+});
+
+test('new Segment(object) with data', function() {
+    var segment = new Segment({ point: { x: 10, y: 10 }, handleIn: { x: 5, y: 5 }, handleOut: { x: 15, y: 15 }, data: { test: true} });
+    equals(segment.data.test, true);
+});
+
 test('new Segment(point, handleIn, handleOut)', function() {
     var segment = new Segment(new Point(10, 10), new Point(5, 5), new Point(15, 15));
     equals(segment.toString(), '{ point: { x: 10, y: 10 }, handleIn: { x: 5, y: 5 }, handleOut: { x: 15, y: 15 } }');


### PR DESCRIPTION
### Description
Add new features to the segments. Now able to add a name or data to the segment. You can search for segment on the path by its name or by its data.

#### Related issues

- Relates to https://github.com/paperjs/paper.js/issues/1459

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
