### PR TITLE
Fix mousedrag error with in front items

### DIFF
--- a/src/view/View.js
+++ b/src/view/View.js
@@ -1271,11 +1271,12 @@ new function() { // Injection scope for event handling on the browser
                     point, prevPoint)
             // Next handle the hit-item, if it's different from the drag-item
             // and not a descendant of it (in which case it would already have
-            // received an event in the call above).
+            // received an event in the call above). Translate mousedrag to
+            // mousemove, since drag is handled above.
             || hitItem && hitItem !== dragItem
                 && !hitItem.isDescendant(dragItem)
-                && emitMouseEvent(hitItem, null, type, event, point, prevPoint,
-                    dragItem)
+                && emitMouseEvent(hitItem, null, type === 'mousedrag' ?
+                'mousemove' : type, event, point, prevPoint, dragItem)
             // Lastly handle the mouse events on the view, if we're still here.
             || emitMouseEvent(view, dragItem || hitItem || view, type, event,
                     point, prevPoint));

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -1276,7 +1276,7 @@ new function() { // Injection scope for event handling on the browser
             || hitItem && hitItem !== dragItem
                 && !hitItem.isDescendant(dragItem)
                 && emitMouseEvent(hitItem, null, type === 'mousedrag' ?
-                'mousemove' : type, event, point, prevPoint, dragItem)
+                    'mousemove' : type, event, point, prevPoint, dragItem)
             // Lastly handle the mouse events on the view, if we're still here.
             || emitMouseEvent(view, dragItem || hitItem || view, type, event,
                     point, prevPoint));

--- a/test/tests/Interactions.js
+++ b/test/tests/Interactions.js
@@ -334,3 +334,14 @@ test('Item#onMouseDrag() is not triggered after mouse up', function(assert) {
     expect(1);
 });
 
+test('Item#onMouseDrag() is not triggered if mouse down was on another item', function(assert) {
+    var item = new Path.Rectangle(new Point(0, 0), new Size(10));
+    item.fillColor = 'red';
+    var item2 = item.clone().translate(10);
+    item2.onMouseDrag = function(event) {
+        throw 'this should not be called';
+    };
+    triggerMouseEvent('mousedown', new Point(5, 5));
+    triggerMouseEvent('mousemove', new Point(11, 11));
+    expect(0);
+});


### PR DESCRIPTION
When dragging item A behind item B, mousedrag event is emitted on
item B instead of mousemove.
Demonstration in this [Sketch](http://sketch.paperjs.org/#S/vZJNa8MwDIb/isilLctCL4ORssPWXQeDDXZoe3AcpfHiWMVW0kHpf5+c0A/YaTvMYIxfS9b7yD4kTrWY5Mlbg6zrJE00lXHfKw+GsX2EB3C4h1fFdbY0XlucHtZ+7UCGRsfoc+gN7rNxAzewur2fpzDfpKcwr0rThRzu5mepMtYuyZIkT8grt8XJ+SywpwY/TMm15Jxlci/UBXz2aptD1TnNhtwUeyk7gwPXJmQ7Ciaq4nnQRTCOF8d4xXG2iEucJ7anP7D9Dq2w3X+CDTDx5B2/+AqFxL1j8RNrwNhv0AMwUC9g0af4QGCCgLLUCGWM3XkqLLbZBWKo/KMt0hV59UtfPrvApjJaRddSeIycXPmVr1Z4VM1wX0jy1eb4DQ==).

Bug introduced in fbd5eeb7ef12fe5f30565dd2b9fcdac3631c1e54
Closes #1465
