### PR TITLE
Fix first mouse drag event is emitted twice

### DIFF
--- a/src/tool/Tool.js
+++ b/src/tool/Tool.js
@@ -309,7 +309,9 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
                 // so there's always a delta.
                 toolPoint = move ? tool._point : (tool._downPoint || pt);
             if (move) {
-                if (tool._moveCount && pt.equals(toolPoint)) {
+                // After first move event was emitted, tool._moveCount = 0, so
+                // we need to include 0 in this check.
+                if (tool._moveCount >= 0 && pt.equals(toolPoint)) {
                     return false;
                 }
                 if (toolPoint && (minDistance != null || maxDistance != null)) {


### PR DESCRIPTION
### Description



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1447

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
