### PR TITLE
Fix SVG export with group clipping mask

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -69,16 +69,52 @@ new function() {
         var node = SvgElement.create('g', attrs, formatter);
         for (var i = 0, l = children.length; i < l; i++) {
             var child = children[i];
-            var childNode = exportSVG(child, options);
-            if (childNode) {
-                if (child.isClipMask()) {
-                    var clip = SvgElement.create('clipPath');
-                    clip.appendChild(childNode);
-                    setDefinition(child, clip, 'clip');
-                    SvgElement.set(node, {
-                        'clip-path': 'url(#' + clip.id + ')'
-                    });
+            // If item is a clip mask...
+            if (child.isClipMask()) {
+                var items = [];
+                // ...and a group...
+                if (child instanceof Group) {
+                    // Work on a copy to avoid messing up with original item.
+                    var clone = child.clone({ insert: false });
+                    // Apply matrix recursively because individual
+                    // transformations can't be kept in <clipPath>.
+                    clone.matrix.apply(true, true);
+                    // Flatten hierarchy because groups are not allowed in
+                    // <clipPath>.
+                    var extractChildren = function(item, arr) {
+                        if (item instanceof Group) {
+                            for (var j = 0, m = item.children.length; j < m; j++) {
+                                extractChildren(item.children[j], arr);
+                            }
+                        } else {
+                            arr.push(item);
+                        }
+                    };
+                    extractChildren(clone, items);
+                    clone.remove();
+                // ...and a path...
                 } else {
+                    // ...just store it as an array.
+                    items.push(child);
+                }
+
+                // Create <clipPath> element.
+                var clip = SvgElement.create('clipPath');
+                setDefinition(child, clip, 'clip');
+                // Reference it in group node attribute.
+                SvgElement.set(node, { 'clip-path': 'url(#' + clip.id + ')' });
+                for (var j = 0, m = items.length; j < m; j++) {
+                    // Append each clipping path to <clipPath>
+                    var childNode = exportSVG(items[j], options);
+                    if (childNode) {
+                        clip.appendChild(childNode);
+                    }
+                }
+            // If item is not a clip mask...
+            } else {
+                // ...append it to the group node.
+                var childNode = exportSVG(child, options);
+                if (childNode) {
                     node.appendChild(childNode);
                 }
             }

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -212,4 +212,22 @@ if (!isNode) {
             tolerance: 1e-2
         });
     });
+
+    test('Export SVG with group as clip mask', function(assert) {
+        var r1 = new Path.Rectangle(new Point(0, 0), new Size(100));
+        var r2 = new Path.Rectangle(new Point(150, 0), new Size(100));
+        var c = new Path.Circle(new Point(125, 50), 75);
+
+        c.fillColor = 'blue';
+
+        var clippingGroup = new Group(r1, r2);
+
+        var group = new Group(clippingGroup, c);
+        group.clipped = true;
+
+        var svg = project.exportSVG({ bounds: 'content', asString: true });
+        compareSVG(assert.async(), svg, project.activeLayer, null, {
+            tolerance: 1e-2
+        });
+    });
 }


### PR DESCRIPTION
### Description

Following SVG spec, groups need to be removed from `<clipPath>` element children.
In order to support the widest range of use cases, when exporting a group with another group set as a clip mask, hierarchy is flattened and matrix is recursively applied.



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1445
- Closes #1590

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
