### PR TITLE
Fix error after setting view zoom

### DIFF
--- a/src/view/View.js
+++ b/src/view/View.js
@@ -533,8 +533,16 @@ var View = Base.extend(Emitter, /** @lends View# */{
     },
 
     setZoom: function(zoom) {
-        this.transform(new Matrix().scale(zoom / this.getZoom(),
-            this.getCenter()));
+        // Make sure value does not break execution (#1433).
+        // Max scale value is the result of Math.sqrt(Number.MAX_VALUE),
+        // it ensure that matrix can be inverted when calling getBound().
+        var maxScale = 1.3407807929942596e+154;
+        var scale = zoom / this.getZoom();
+        if (scale === 0) scale = Numerical.EPSILON;
+        else if (scale > maxScale) scale = maxScale;
+        else if (scale < -maxScale) scale = -maxScale;
+
+        this.transform(new Matrix().scale(scale, this.getCenter()));
     },
 
     /**

--- a/test/tests/View.js
+++ b/test/tests/View.js
@@ -1,0 +1,23 @@
+/*
+ * Paper.js - The Swiss Army Knife of Vector Graphics Scripting.
+ * http://paperjs.org/
+ *
+ * Copyright (c) 2011 - 2016, Juerg Lehni & Jonathan Puckey
+ * http://scratchdisk.com/ & http://jonathanpuckey.com/
+ *
+ * Distributed under the MIT license. See LICENSE file for details.
+ *
+ * All rights reserved.
+ */
+
+QUnit.module('View');
+
+test('View#setZoom does not break execution', function() {
+    view.setZoom(0);
+    view.getBounds();
+    view.setZoom(Infinity);
+    view.getBounds();
+    view.setZoom(-Infinity);
+    view.getBounds();
+    expect(0);
+});

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -62,3 +62,5 @@
 /*#*/ include('SvgExport.js');
 
 /*#*/ include('Numerical.js');
+
+/*#*/ include('View.js');


### PR DESCRIPTION
### Description
Make sure view matrix is invertible by restricting zoom allowed values.
Convert extremely low, null and extremely high value, to the nearest possible value.
Based on this idea https://github.com/paperjs/paper.js/issues/1433#issuecomment-360197572.


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1433

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
