### PR TITLE
Improve hit test point documentation

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1905,6 +1905,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @option options.selected {Boolean} only hit selected items
      *
      * @param {Point} point the point where the hit-test should be performed
+     *     (in global coordinates system).
      * @param {Object} [options={ fill: true, stroke: true, segments: true,
      *     tolerance: settings.hitTolerance }]
      * @return {HitResult} a hit result object describing what exactly was hit
@@ -1922,6 +1923,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @name Item#hitTestAll
      * @function
      * @param {Point} point the point where the hit-test should be performed
+     *     (in global coordinates system).
      * @param {Object} [options={ fill: true, stroke: true, segments: true,
      *     tolerance: settings.hitTolerance }]
      * @return {HitResult[]} hit result objects for all hits, describing what


### PR DESCRIPTION
### Description
Specifies that hit test point should be provided in global coordinates system.


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1430

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
