### PR TITLE
Fix item global matrix error

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4298,8 +4298,12 @@ new function() { // Injection scope for hit-test functions shared with project
             // Apply the parent's global matrix to the calculation of correct
             // bounds.
             var bounds = this.getStrokeBounds(viewMatrix);
-            if (!bounds.width || !bounds.height)
+            if (!bounds.width || !bounds.height) {
+                // Item won't be drawn so its global matrix need to be removed
+                // from the stack (#1561).
+                matrices.pop();
                 return;
+            }
             // Store previous offset and save the main context, so we can
             // draw onto it later.
             prevOffset = param.offset;

--- a/test/tests/Item_Bounds.js
+++ b/test/tests/Item_Bounds.js
@@ -789,3 +789,12 @@ test('group.internalBounds with child and child.applyMatrix = false (#1250)', fu
     equals(group.internalBounds, new Rectangle(0, 0, 250, 250),
             'group.internalBounds after scaling item1');
 });
+
+test('#1561 item._globalMatrix on item after empty symbol', function(){
+    var symbol = new SymbolItem(new Path());
+    symbol.opacity = 0.5;
+    symbol.skew(10);
+    var item = new Path.Circle(new Point(0,0), 10);
+    view.update();
+    equals(item._globalMatrix, new Matrix());
+});


### PR DESCRIPTION
### Description
Bug happen when item is drawn after an empty symbol that should be drawn in a separate canvas context (partial opacity or special blend mode).
As bounds are empty, symbol drawing process is interrupted but its global matrix is not removed from the stack.



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1561

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
