### PR TITLE
Improve color parsing for 4 character hex code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ solid fixes, as we are paving the way for the upcoming release of `1.0.0`. Here 
 - Draw shadows on `Raster` images (#1437)
 - Fix boolean operation edge case (#1506, #1513, #1515).
 - Remove memory leak on gradient colors (#1499).
-- Support alpha channel in CSS colors (#1468, #1539).
+- Support alpha channel in CSS colors (#1468, #1539, #1565).
 - Improve color CSS string parsing and documentation.
 - Improve caching of item positions (#1503).
 - Always draw selected position in global coordinates system (#1545).

--- a/src/style/Color.js
+++ b/src/style/Color.js
@@ -64,7 +64,7 @@ var Color = Base.extend(new function() {
         var match = string.match(
                 /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})([\da-f]{2})?$/i
             ) || string.match(
-                /^#([\da-f])([\da-f])([\da-f])$/i
+                /^#([\da-f])([\da-f])([\da-f])([\da-f])?$/i
             ),
             type = 'rgb',
             components;

--- a/test/tests/Color.js
+++ b/test/tests/Color.js
@@ -69,8 +69,11 @@ test('Creating Colors', function() {
     equals(new Color('#FF3300'), new Color(1, 0.2, 0),
             'Color from uppercase hex string');
 
+    equals(new Color('#f009'), new Color(1, 0, 0, .6),
+        'Color from 4 characters hex code with alpha');
+
     equals(new Color('#ff000099'), new Color(1, 0, 0, .6),
-        'Color from hex code with alpha');
+        'Color from 8 characters hex code with alpha');
 
     equals(new Color('rgb(255, 0, 0)'), new Color(1, 0, 0),
             'Color from rgb() string');


### PR DESCRIPTION
### Description

Adding feature of color parsing for 4 character hex code (like `#f009`).

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to #1469

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
