### PR TITLE
Fix single segment closed path flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ solid fixes, as we are paving the way for the upcoming release of `1.0.0`. Here 
 - Prevent `paper` object from polluting the global scope (#1544).
 - Make sure `Path#arcTo()` always passes through the provide through point
   (#1477).
-- Draw shadows on `Raster` images (#1437)
+- Draw shadows on `Raster` images (#1437).
 - Fix boolean operation edge case (#1506, #1513, #1515).
+- Fix single segment closed path flatten error (#1338, #1569).
 - Remove memory leak on gradient colors (#1499).
 - Support alpha channel in CSS colors (#1468, #1539, #1565).
 - Improve color CSS string parsing and documentation.

--- a/src/path/PathFlattener.js
+++ b/src/path/PathFlattener.js
@@ -95,7 +95,7 @@ var PathFlattener = Base.extend({
             segment1 = segment2;
         }
         if (path._closed)
-            addCurve(segment2, segments[0]);
+            addCurve(segment2 || segment1, segments[0]);
         this.curves = curves;
         this.parts = parts;
         this.length = length;

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -450,6 +450,13 @@ test('Path#flatten(maxDistance)', function() {
     }, true, 'The points of the last and before last segments should not be so close, that calling toString on them returns the same string value.');
 });
 
+test('Path#single segment closed path flatten (#1338)', function() {
+    var p = PathItem.create("m445.26701,223.69688c6.1738,8.7566 -7.05172,14.0468 0,0z");
+    p.strokeColor = "red";
+    p.flatten();
+    expect(0);
+});
+
 test('Path#curves after removing a segment - 1', function() {
     var path = new paper.Path([0, 0], [1, 1], [2, 2]);
     var prevCurves = path.curves.slice();


### PR DESCRIPTION
### Description

This PR fixes single segment closed path flatten error.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1338

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
