### PR TITLE
Fix clip item matrix is ignored in group internal bounds

### DIFF
--- a/src/item/Group.js
+++ b/src/item/Group.js
@@ -172,7 +172,7 @@ var Group = Item.extend(/** @lends Group# */{
         var clipItem = this._getClipItem();
         return clipItem
             ? clipItem._getCachedBounds(
-                matrix && matrix.appended(clipItem._matrix),
+                matrix && matrix.appended(clipItem._matrix) || clipItem._matrix,
                 Base.set({}, options, { stroke: false }))
             : _getBounds.base.call(this, matrix, options);
     },

--- a/test/tests/Group.js
+++ b/test/tests/Group.js
@@ -134,4 +134,17 @@ test('group.addChildren()', function() {
     group.addChildren(children);
     equals(group.children.length, 2,
             'adding the same item twice should only add it once.');
-})
+});
+
+test('group.getInternalBounds() with clip item without matrix applied', function() {
+    var point = new Point(100, 100);
+    var translation = new Point(100, 100);
+    var item = new Path.Circle({ center: point, radius: 50, fillColor: 'orange' });
+    var clip = new Path.Rectangle({ from: point.subtract(translation), to: point.add(translation) });
+    clip.applyMatrix = false;
+    clip.translate(translation);
+    var group = new Group(clip, item);
+    group.clipped = true;
+
+    equals(group.getInternalBounds(), new Rectangle(point, point.add(translation.multiply(2))));
+});


### PR DESCRIPTION
### Description
In a group, when clip item had matrix not applied, its matrix was ignored in group internal bounds calculation, resulting in misplaced group selected bounds.

Here is the [sketch](http://sketch.paperjs.org/#S/hVTLbtswEPyVhS6SW0VxCuTiIpfmUBRogaLtLclhLa5txhQpkJTtwPC/d0nqZaAPARZoz87sDLn0OdPYULbKfu7J17uszGojwvcDWmiN1B4eQNMRvod1cbdclsCvxcdn+6xDjbeonUIvjf5HZfjc3oKweASEWtpa0aAgPTUDFf2ueoxocYaatCe7SjZKsChk51Zwz8IbqdSjUYbR3LCDLeVwSa2mNpZqz5AiOEq/M52HBr2VJ8C2VZLEYKBWsp0b+DHw2MPGmqZ3ADfzsCV4MwDvr3ah9xFUq9Dp7Vvq+gAbVI4GkwOFJp8jbcSKmfDVTqIQsDZ+F3fPsRfOu7WmawG1gM7NVAFditig2w+ZU20K/Tmsi1BSRrnUKFb8NUBCA6clwYi3Hc39OVLcv2+zNp0WLjq7yppEElolxrVY3Iz/AnEQGM0tiXw0URvtjKJKmW2R06mNpXkZE08n3M/Wn87xHXxY9Ec5l8Lad6hYKLnfkv8SxlSj+hSDFIvpoMbr8ItOvjiHn4Af1vM82zy7iQKOp1MJMAeyCtu8HAqjrWnKnnjyb+7uly9jwWvnvNzIOjpmvXRl8gBfJhutNa+cuGLr8kBf8Y1s1Ron+0t7kHSsEjNS+E9gbQn3sa3LVk8vl98=) reproducing the bug.

![screenshot-127 0 0 1-8080-2018 10 17-09-54-14](https://user-images.githubusercontent.com/11247504/47072006-5bac2080-d1f5-11e8-805e-e42c4c924cab.png)



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1427

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
