### PR TITLE
Add documentation for PaperScope#setup(size)

### DIFF
--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -249,9 +249,10 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
      * Sets up an empty project for us. If a canvas is provided, it also creates
      * a {@link View} for it, both linked to this scope.
      *
-     * @param {HTMLCanvasElement|String} element the HTML canvas element this
-     * scope should be associated with, or an ID string by which to find the
-     * element.
+     * @param {HTMLCanvasElement|String|Size} element the HTML canvas element
+     * this scope should be associated with, or an ID string by which to find
+     * the element, or the size of the canvas to be created for usage in a web
+     * worker.
      */
     setup: function(element) {
         // Make sure this is the active scope, so the created project and view

--- a/src/item/Project.js
+++ b/src/item/Project.js
@@ -44,9 +44,10 @@ var Project = PaperScopeItem.extend(/** @lends Project# */{
      * Note that when working with PaperScript, a project is automatically
      * created for us and the {@link PaperScope#project} variable points to it.
      *
-     * @param {HTMLCanvasElement|String} element the HTML canvas element that
-     * should be used as the element for the view, or an ID string by which to
-     * find the element.
+     * @param {HTMLCanvasElement|String|Size} element the HTML canvas element
+     * that should be used as the element for the view, or an ID string by which
+     * to find the element, or the size of the canvas to be created for usage in
+     * a web worker.
      */
     initialize: function Project(element) {
         // Activate straight away by passing true to PaperScopeItem constructor,


### PR DESCRIPTION
### Description
Documentation did not mention that a size can be passed as argument to PaperScope#setup() and Project#initialize() for usage of paper.js in web workers.





#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1412

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
