### PR TITLE
Fix mouse interactions tests error

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -34,6 +34,16 @@ if (isNode) {
     });
 }
 
+// Some native javascript classes have name collisions with Paper.js classes.
+// If they have not already been stored in src/load.js, we dot it now.
+if (!isNode && typeof NativeClasses === 'undefined')
+{
+    NativeClasses = {
+        Event: Event,
+        MouseEvent: MouseEvent
+    };
+}
+
 // The unit-tests expect the paper classes to be global.
 paper.install(scope);
 
@@ -74,7 +84,7 @@ var test = function(testName, expected) {
 
         // Instantiate project with 100x100 pixels canvas instead of default
         // 1x1 to make interactions tests simpler by working with integers.
-        currentProject = new Project(CanvasProvider.getCanvas(100, 100));
+        currentProject = new Project(new Size(100, 100));
         expected(assert);
     });
 };

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -64,4 +64,6 @@
 /*#*/ include('Numerical.js');
 
 // There is no need to test interactions in node context.
-/*#*/ if (!isNode) include('Interactions.js');
+if (!isNode) {
+    /*#*/ include('Interactions.js');
+}

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -64,4 +64,4 @@
 /*#*/ include('Numerical.js');
 
 // There is no need to test interactions in node context.
-if (!isNode) /*#*/ include('Interactions.js');
+/*#*/ if (!isNode) include('Interactions.js');


### PR DESCRIPTION
### Description
Mouse interactions tests only passed in `gulp load` context.
This make sure that native event classes are used in built context.
This also remove the reference to `CanvasProvider` which is not available in built context.




#### Related pull request

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Fixes bug introduced in #1570

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
