### PR TITLE
Fix exported SVG missing viewBox attribute

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -427,7 +427,7 @@ new function() {
             if (rect) {
                 attrs.width = rect.width;
                 attrs.height = rect.height;
-                if (rect.x || rect.y)
+                if (rect.x || rect.x === 0 || rect.y || rect.y === 0)
                     attrs.viewBox = formatter.rectangle(rect);
             }
             var node = SvgElement.create('svg', attrs, formatter),

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -113,6 +113,12 @@ test('Export SVG path at precision 0', function() {
     equals(path.exportSVG({ precision: 0 }).getAttribute('d'), 'M0,2l1,1');
 });
 
+test('Export SVG viewbox attribute with top left at origin', function() {
+    var path = new Path.Rectangle(new Point(10, 10), new Size(80));
+    var rectangle = new Rectangle(new Point(0, 0), new Size(100));
+    equals(project.exportSVG({ bounds: rectangle }).getAttribute('viewBox'), '0,0,100,100');
+});
+
 if (!isNode) {
     // JSDom does not have SVG rendering, so we can't test there.
     test('Export transformed shapes', function(assert) {


### PR DESCRIPTION
### Description
SVG viewBox attribute was not added when bounds rectangle point was 0,0.
Bug is reproduced in this [sketch](http://sketch.paperjs.org/#S/TZCxjsIwDEB/JcpCK1VVGVhyIwPr6SrdAgwhNSVHsCvH1Z2E+u8kVHC1lESxn+On3DXaG2ij2yuIu+hKO+ryHeFXfVq51FvPLkBxP/ABVQoHKMBGPQHyKMWmqdSmKasXwbbzYzQp906dfQhbCpT6VsQWe1jl0lR+5CMvRxgpQB2oLwamH3BSw99ALO337n+6ja2wx94o4RHe759oxC7OUl+pNU1YOj8VmG5L6yS9cM4htKyvm0SkrXwhUzkrz87pp04M9jpkOGqzP04P).

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to https://groups.google.com/forum/#!topic/paperjs/am413XCGuzE

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
