### PR TITLE
Fix symbol definition selection is drawn

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -626,6 +626,10 @@ new function() { // Injection scope for various item event handlers
     },
 
     setSelected: function(selected) {
+        // Do not select item if it is used as a symbol definition.
+        if (this._symbol) {
+            return;
+        }
         if (this._selectChildren) {
             var children = this._children;
             for (var i = 0, l = children.length; i < l; i++)


### PR DESCRIPTION
### Description
When an item used as symbol definition was selected after symbol definition creation, its selection was drawn, resulting in an unexpected display.
Here is the [sketch](http://sketch.paperjs.org/#S/jVLLbsIwEPyVVS6kahoCUqUqVU/00ktVid6Ag+NsyBbHRrYDrRD/XjsmCfRUS5a1j5kde3yKJGswyqPlDi2voyTiqvTxdAqlZkdgwElzgWu9lgemLxG8gMQjfDBbp4suE598B7jFUVrUORwIj2kIkr6mWUmtyeExG1IVCbFQQjnERGkmtzjxpfPdsz/8dlIatkMnpcSKJFlSspczZi6Slj9NocTrkI6D4Bu2vWAcYQ6m6zU9VwhnN0RvFpt4HJJc3ypwjsj5v5FwD7Msu9FkUCC3oDRtSTIB5OC+FOSnoYylG2F1iwOyc0GRtJ/4ba88UG6MtO5J35VEUBXYGi/eGTC1akUJBUJPOxns2Huy/I/YVZbAw1O2Gbq+WmOpIs781dyU0HltnPtJhUa26/hMlK82518=) reproducing the bug.
![screenshot-sketch paperjs org-2018 10 20-11-19-19](https://user-images.githubusercontent.com/11247504/47253877-13da0300-d45a-11e8-9989-e2130e4e36ea.png)





### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
