### PR TITLE
Minor code minifier

### DIFF
--- a/src/basic/Matrix.js
+++ b/src/basic/Matrix.js
@@ -672,12 +672,11 @@ var Matrix = Base.extend(/** @lends Matrix# */{
     },
 
     /**
-     * Attempts to decompose the affine transformation described by this matrix
-     * into `scaling`, `rotation` and `skewing`, and returns an object with
-     * these properties if it succeeded, `null` otherwise.
+     * Decomposes the affine transformation described by this matrix into
+     * `scaling`, `rotation` and `skewing`, and returns an object with
+     * these properties.
      *
-     * @return {Object} the decomposed matrix, or `null` if decomposition is not
-     *     possible
+     * @return {Object} the decomposed matrix
      */
     decompose: function() {
         // http://dev.w3.org/csswg/css3-2d-transforms/#matrix-decomposition
@@ -795,7 +794,7 @@ var Matrix = Base.extend(/** @lends Matrix# */{
      * @see #decompose()
      */
     getScaling: function() {
-        return (this.decompose() || {}).scaling;
+        return this.decompose().scaling;
     },
 
     /**
@@ -806,7 +805,7 @@ var Matrix = Base.extend(/** @lends Matrix# */{
      * @see #decompose()
      */
     getRotation: function() {
-        return (this.decompose() || {}).rotation;
+        return this.decompose().rotation;
     },
 
     /**

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -525,11 +525,9 @@ var View = Base.extend(Emitter, /** @lends View# */{
      * @see #getScaling()
      */
     getZoom: function() {
-        var decomposed = this._decompose(),
-            scaling = decomposed && decomposed.scaling;
-        // Use average since it can be non-uniform, and return 0 when it can't
-        // be decomposed.
-        return scaling ? (scaling.x + scaling.y) / 2 : 0;
+        var scaling = this._decompose().scaling;
+        // Use average since it can be non-uniform.
+        return (scaling.x + scaling.y) / 2;
     },
 
     setZoom: function(zoom) {
@@ -545,8 +543,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      * @type Number
      */
     getRotation: function() {
-        var decomposed = this._decompose();
-        return decomposed && decomposed.rotation;
+        return this._decompose().rotation;
     },
 
     setRotation: function(rotation) {
@@ -565,11 +562,8 @@ var View = Base.extend(Emitter, /** @lends View# */{
      * @see #getZoom()
      */
     getScaling: function() {
-        var decomposed = this._decompose(),
-            scaling = decomposed && decomposed.scaling;
-        return scaling
-                ? new LinkedPoint(scaling.x, scaling.y, this, 'setScaling')
-                : undefined;
+        var scaling = this._decompose().scaling;
+        return new LinkedPoint(scaling.x, scaling.y, this, 'setScaling');
     },
 
     setScaling: function(/* scaling */) {


### PR DESCRIPTION
### Description
We can minify some codes which relate matrix.decompose(),
because matrix.decompose() must return non-null object

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
