### PR TITLE
Fix transform attribution in SvgExport

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -36,29 +36,7 @@ new function() {
             trans = null;
         }
         if (!matrix.isIdentity()) {
-            // See if we can decompose the matrix and can formulate it as a
-            // simple translate/scale/rotate command sequence.
-            var decomposed = matrix.decompose();
-            if (decomposed) {
-                var parts = [],
-                    angle = decomposed.rotation,
-                    scale = decomposed.scaling,
-                    skew = decomposed.skewing;
-                if (trans && !trans.isZero())
-                    parts.push('translate(' + formatter.point(trans) + ')');
-                if (angle)
-                    parts.push('rotate(' + formatter.number(angle) + ')');
-                if (!Numerical.isZero(scale.x - 1)
-                        || !Numerical.isZero(scale.y - 1))
-                    parts.push('scale(' + formatter.point(scale) +')');
-                if (skew.x)
-                    parts.push('skewX(' + formatter.number(skew.x) + ')');
-                if (skew.y)
-                    parts.push('skewY(' + formatter.number(skew.y) + ')');
-                attrs.transform = parts.join(' ');
-            } else {
-                attrs.transform = 'matrix(' + matrix.getValues().join(',') + ')';
-            }
+            attrs.transform = 'matrix(' + matrix.getValues().join(',') + ')';
         }
         return attrs;
     }


### PR DESCRIPTION
### Description
There are some cases that matrix cannot be described by affine transformation.
To avoid such cases, we should not use affine transformation created by
matrix.decompose(), but use matrix transformation.


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
