### PR TITLE
Fix SvgExport when item.matrix is not invertible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## `Prebuilt`
+
+### Fixed
+
+- Fix SvgExport error when item.matrix is not invertible (#1580).
+
 ## `0.11.8`
 
 ### News

--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -29,11 +29,16 @@ new function() {
             // in rotate(). To do so, SVG requries us to inverse transform the
             // translation point by the matrix itself, since they are provided
             // in local coordinates.
-            matrix = matrix._shiftless();
-            var point = matrix._inverseTransform(trans);
+            var point;
+            if (matrix.isInvertible()) {
+                matrix = matrix._shiftless();
+                point = matrix._inverseTransform(trans);
+                trans = null;
+            } else {
+                point = new Point();
+            }
             attrs[center ? 'cx' : 'x'] = point.x;
             attrs[center ? 'cy' : 'y'] = point.y;
-            trans = null;
         }
         if (!matrix.isIdentity()) {
             // See if we can decompose the matrix and can formulate it as a

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -149,6 +149,17 @@ if (!isNode) {
         compareSVG(assert.async(), svg, project.activeLayer);
     });
 
+    test('Export not invertible item.matrix', function(assert) {
+        var rect = new Shape.Rectangle({
+            point: [100, 100],
+            size: [100, 100],
+            fillColor: 'red',
+            matrix: [1, 1, 1, 1, 1, 1]
+        });
+        var svg = project.exportSVG({ bounds: 'content', asString: true });
+        compareSVG(assert.async(), svg, project.activeLayer);
+    });
+
     test('Export gradients', function(assert) {
         var bounds = new Rectangle(new Size(300, 600));
         var stops = [new Color(1, 1, 0, 0), 'red', 'black'];


### PR DESCRIPTION
This PR fixes error in #1580.

Add: Travis error is in nodejs v11 which released recently. It is not related to this PR.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1580

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
