### PR TITLE
Travis: Remove node v9 and add node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
 - stable
-- 9
+- 10
 - 8
 # 6.13 and 6.14 causing unreasonable errors in SymbolDefinition.initialize.
 # https://travis-ci.org/paperjs/paper.js/jobs/434854796


### PR DESCRIPTION
### Description
From the [release schedule of nodejs](https://github.com/nodejs/Release#release-schedule), I remove nodejs v9 because of end-of-life.
We add v10 to travis, because `stable` version means v11. (v11 is released in 23th, Oct. !)