### PR TITLE
Fix crashing build disabling node v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
-- stable
+# Stable version is temporarily disabled due to a bug in resemblejs package with
+# node v11 (https://github.com/orgs/paperjs/teams/contributors/discussions/8).
+# - stable
 - 10
 - 8
 # 6.13 and 6.14 causing unreasonable errors in SymbolDefinition.initialize.


### PR DESCRIPTION
### Description
Node v11 is temporarily disabled from ci build until a bug is fixed in `resemblejs` package.
