### PR TITLE
Fix Item#importJSON override Item#insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Prebuilt version
+
+### Fixed
+
+- Prevent `Item#importJSON()` from overriding `Item#insert()` (#1392).
+
+### Added
+
 ## `0.11.8`
 
 ### News

--- a/src/core/Base.js
+++ b/src/core/Base.js
@@ -558,8 +558,17 @@ statics: /** @lends Base */{
                     if (args.length === 1 && obj instanceof Item
                             && (useTarget || !(obj instanceof Layer))) {
                         var arg = args[0];
-                        if (Base.isPlainObject(arg))
+                        if (Base.isPlainObject(arg)) {
                             arg.insert = false;
+                            // When using target, make sure `item.insert()`
+                            // method is not overriden with item properties.
+                            // We add an exclude object that will be passed as
+                            // argument when calling `obj.set` below.
+                            // See #1392.
+                            if (useTarget) {
+                                args.push({insert: true});
+                            }
+                        }
                     }
                     // When reusing an object, initialize it through #set()
                     // instead of the constructor function:

--- a/test/tests/JSON.js
+++ b/test/tests/JSON.js
@@ -256,3 +256,10 @@ test('Path#importJSON()', function() {
     equals(function() { return layer.firstChild === path; }, true);
     equals(function() { return path.parent === layer; }, true);
 });
+
+test('Item#importJSON() do not override Item#insert()', function() {
+    var path = new Path();
+    equals('function', typeof path.insert);
+    path.importJSON(path.exportJSON());
+    equals('function', typeof path.insert);
+});


### PR DESCRIPTION
### Description
When calling `item.importJSON()`, `item.insert()` was overriden along with item properties. An exclude 
 object is passed to `Base.set()` to prevent that from happening.





#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1392

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
