### PR TITLE
Fix item drawing within a clipped group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Prebuilt version
+
+### Fixed
+
+- Fix item with matrix not applied drawing within a clipped group (#1594).
+
+### Added
+
 ## `0.11.8`
 
 ### News

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4389,12 +4389,13 @@ new function() { // Injection scope for hit-test functions shared with project
             // on the temporary canvas.
             ctx.translate(-itemOffset.x, -itemOffset.y);
         }
+        // Draw clip item before applying transformation (see #1594).
+        if (clip) {
+            param.clipItem.draw(ctx, param.extend({ clip: true }));
+        }
         if (transform) {
             // Apply viewMatrix when drawing into temporary canvas.
             (direct ? matrix : viewMatrix).applyToContext(ctx);
-        }
-        if (clip) {
-            param.clipItem.draw(ctx, param.extend({ clip: true }));
         }
         if (strokeMatrix) {
             // Reset the transformation but take HiDPI pixel ratio into account.

--- a/test/tests/Item.js
+++ b/test/tests/Item.js
@@ -945,3 +945,23 @@ test('Children global matrices are cleared after parent transformation', functio
     group.translate(100, 0);
     equals(item.localToGlobal(item.getPointAt(0)), new Point(100, 100));
 });
+
+test('Item#draw within a clipped group with matrix not applied', function() {
+    var method = function(blendMode){
+        new Path.Circle(new Point(0, 0), 200);
+        project.activeLayer.clipped = true;
+        var item = new Group(new Path.Rectangle(
+            new Point(0, 0),
+            new Point(200, 200)
+        ));
+        item.applyMatrix = false;
+        item.scaling = [0.5, 0.5];
+        item.fillColor = 'black';
+        item.blendMode = blendMode;
+    };
+    compareCanvas(200, 200,
+        function() {method('normal');},
+        function() {method('add');},
+        0.0004
+    );
+});


### PR DESCRIPTION
### Description
When item was part of a clipped group and a child of a group with matrix not applied that had transformations and when item needed to be drawn in a separated canvas (partial opacity, special blend mode, ...), item drawing was incorrectly clipped.
Drawing clip item before applying transformations to the context in `Item#draw()` fixes this problem.

The bug is reproduced in this [sketch](http://sketch.paperjs.org/#V/0.11.8/S/ZVPNbptAEH6VERewZBFUyQc78qU59NKqVZqb48OwjGHLsrNaFjtWlHfvDtjEkZE4sDP7/c3wnljsKNkkf1sKqkmWieJKvh8eAKsKEJTRrsO+hcAQGgJUQR8JDJ7Jv/pXe0QPyrODLVg6wR8MTf6kvTKU7YolFPslfCuKxaP0Os//SIV8wvgpELngO6ri9eAHGtvkjfx9w6eZ/kpVsq/Ix27hjJfZUjaBT5W8D55bemLD0pWWBlWb3sIqTxiiD6g9Dw5OOjTQYfD6DSwHQOeMpurKpwN1F2s/pD+bTT5HJ2jr6FN6IT5jibUNmRhfLO/PYxJTHFJaTLqFIRfW869JxRYOaPopColBoaGoQwbQYUvjFMqhBi6Pmod+xpBGbet4f1fkq6ggX+1vjZ/Yt7G+gcNgDLBDpcMZFPZ0NSuF35fz7Wj9S8I35fygjZlDrj2RTe96erLVC3+PA7gAXIQcUJtRiEMfNN5rGZl5FlLk6/X6M6sv1J6qz+nOQb/QW8jer/krtoFs2ED6HBcNbQWj4Lhg6KiXPRtMJTugmnQemhOcDexWMrC9nH4sHuP/Ucb1acdin2x2+4//).

![screenshot-sketch paperjs org-2018 11 06-12-17-50](https://user-images.githubusercontent.com/11247504/48061044-004ecc00-e1be-11e8-8fc1-09dbaabe9915.png)





#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1594

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
