### PR TITLE
Add SVG switch support

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -303,7 +303,11 @@ new function() {
                     getPoint(node, 'dx', 'dy')));
             text.setContent(node.textContent.trim() || '');
             return text;
-        }
+        },
+
+        // https://www.w3.org/TR/SVG/struct.html#SwitchElement
+        // Conditional attributes are ignored and all children are rendered.
+        switch: importGroup
     };
 
     // Attributes and Styles

--- a/test/tests/SvgImport.js
+++ b/test/tests/SvgImport.js
@@ -143,6 +143,21 @@ test('Import SVG without insertion', function() {
     }, true);
 });
 
+test('Import SVG switch', function(assert) {
+    var done = assert.async();
+    var svg = '<svg xmlns="http://www.w3.org/2000/svg"><switch><line x1="0" x2="10" y1="0" y2="10" fill="none"></line></switch></svg>';
+    paper.project.importSVG(svg, {
+        onLoad: function(item) {
+            equals(item.className, 'Group');
+            equals(item.children.length, 1);
+            equals(item.firstChild.className, 'Group');
+            equals(item.firstChild.children.length, 1);
+            equals(item.firstChild.firstChild, new Path([new Point(0, 0), new Point(10, 10)]));
+            done();
+        }
+    });
+});
+
 function importSVG(assert, url, message, options) {
     var done = assert.async();
     project.importSVG(url, {


### PR DESCRIPTION
### Description
Adds support for SVG <switch> element which is simply parsed as a group because conditional attributes cannot be evaluated in paper.js context.
Bug is reproduced [here](http://sketch.paperjs.org/#V/0.11.8/S/RZDBboMwDIZfxcoOdBKCtFMvjCLt1GulTruUHih4JQOSKPEaUNV3X8LEZimy/fvP5yh3JqsBWcaOHVLdspjVqgn9rTJgb1fYQZSHPA69tLuStUQ6S1PnXOJeEmWu6YZznnpLyYrcOuEpRd4LiTCuvZ+XDMaNL9Y8lNOiTf+aJaM69O0TnyOA0kDwaQGGBUX0WppShqON+sKaEjFoZej4sV/5+fPfWKKDgxKS3nGk1T1I4KNWklBSBtEbzC+0rfruG7ggNMLqvpqwASGBWgRSGnr8JH/JSDRRvEB04GZw2vIYtvwc5MfvZv95F4NVNzssy07nxw8=).

![screenshot-sketch paperjs org-2018 11 06-15-53-22](https://user-images.githubusercontent.com/11247504/48072128-1d929300-e1dc-11e8-8ef4-07939878cfa7.png)




#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1389
- Closes #1181

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
