### PR TITLE
Fix drawing with compound path as clip item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Prebuilt version
+
+### Fixed
+
+- Fix drawing with compound path as clip item (#1361).
+
+### Added
+
 ## `0.11.8`
 
 ### News

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4409,8 +4409,11 @@ new function() { // Injection scope for hit-test functions shared with project
         this._draw(ctx, param, viewMatrix, strokeMatrix);
         ctx.restore();
         matrices.pop();
-        if (param.clip && !param.dontFinish)
-            ctx.clip();
+        if (param.clip && !param.dontFinish) {
+            // We need to pass fill rule to clip method to handle compound path
+            // as clip item case (see #1361).
+            ctx.clip(this.fillRule);
+        }
         // If a temporary canvas was created, composite it onto the main canvas:
         if (!direct) {
             // Use BlendMode.process even for processing normal blendMode with

--- a/test/tests/Item.js
+++ b/test/tests/Item.js
@@ -945,3 +945,28 @@ test('Children global matrices are cleared after parent transformation', functio
     group.translate(100, 0);
     equals(item.localToGlobal(item.getPointAt(0)), new Point(100, 100));
 });
+
+test('Item#draw with CompoundPath as clip item', function() {
+    var method = function(invertedOrder){
+        var compound = new CompoundPath({
+            children: [
+                new Path.Circle(new Point(50, 50), 50),
+                new Path.Circle(new Point(100, 50), 50)
+            ],
+            fillRule: 'evenodd'
+        });
+
+        var rectangle = new Shape.Rectangle(new Point(0, 0), new Point(150, 50));
+
+        var group = new Group();
+        group.children = invertedOrder
+            ? [compound, rectangle]
+            : [rectangle, compound];
+        group.fillColor = 'black';
+        group.clipped = true;
+    };
+    compareCanvas(200, 200,
+        function() {method(true);},
+        function() {method(false);}
+    );
+});


### PR DESCRIPTION
### Description
When compound path with `evenodd` fill rule was used as clip item, negative space was filled.
Clip item fill rule is passed to `ctx.clip()` to solve this problem.





#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1361

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
