### PR TITLE
Fix path selection drawing with low handle size

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2172,6 +2172,11 @@ new function() { // Scope for drawing
     // performance.
 
     function drawHandles(ctx, segments, matrix, size) {
+        // Only draw if size is not null or negative.
+        if (size <= 0) {
+            return;
+        }
+
         var half = size / 2,
             coords = new Array(6),
             pX, pY;
@@ -2203,8 +2208,8 @@ new function() { // Scope for drawing
             // Draw a rectangle at segment.point:
             ctx.fillRect(pX - half, pY - half, size, size);
             // If the point is not selected, draw a white square that is 1 px
-            // smaller on all sides:
-            if (!(selection & /*#=*/SegmentSelection.POINT)) {
+            // smaller on all sides. Only draw it if size is big enough (#1327).
+            if (!(selection & /*#=*/SegmentSelection.POINT) && size > 2) {
                 var fillStyle = ctx.fillStyle;
                 ctx.fillStyle = '#ffffff';
                 ctx.fillRect(pX - half + 1, pY - half + 1, size - 2, size - 2);


### PR DESCRIPTION
### Description
Selected points were drawn even when handle size was too low.
This change ensure that not fully selected points are only drawn if handle size is greater than 2 and that nothing is drawn if size is null or negative.

Unfortunately, I couldn't add unit test because there is no equivalent working case to do pixel comparison with.

Bug is reproduced in this [sketch](http://sketch.paperjs.org/#V/0.11.8/S/bZExb8MgEIX/yoklrWQRu1tdZcraoarHJMPZPjvI+LAA12qj/PcCaaMqKRJIvHd370OcBONIohTVQL45ikw0po339Rpa5bDWBEfkVpPb2z1POJGVjrxX3Dt5cSr1RbCB/CVWxB17LS6AUGtsBqjD0VszcwvOwELQIIMjgjoMIhtbmBZ4Q3+U79R45F7TwynqEFZnzVjCLs/yQ/areROUIs8zePqjdkrrrdHGlrBK0avonB//IetmrT8DhA551IJWTLHgAy0oT2N4zxXpNXh3NEWILm6Bnm/EFFL9ZJTg7Uz3QDNfKAK9dR4mo9hHK2LIpFXUj8ReJktemTfQoXaUZoWPqy3hkEqcKHeH8zc=).

![screenshot-sketch paperjs org-2018 11 09-16-04-48](https://user-images.githubusercontent.com/11247504/48270018-44013a00-e439-11e8-9d55-7acaaeb65b2b.png)

Expected:

![screenshot-127 0 0 1-8080-2018 11 09-16-05-03](https://user-images.githubusercontent.com/11247504/48270023-48c5ee00-e439-11e8-937e-c70f160deaa1.png)




#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1327

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
