### PR TITLE
Fix empty image drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Prebuilt version
+
+### Fixed
+
+- Fix empty image drawing (#1320).
+
+### Added
+
 ## `0.11.8`
 
 ### News

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -754,7 +754,7 @@ var Raster = Item.extend(/** @lends Raster# */{
     _draw: function(ctx, param, viewMatrix) {
         var element = this.getElement();
         // Only draw if image is not empty (#1320).
-        if (element && element.width * element.height > 0) {
+        if (element && element.width > 0 && element.height > 0) {
             // Handle opacity for Rasters separately from the rest, since
             // Rasters never draw a stroke. See Item#draw().
             ctx.globalAlpha = this._opacity;

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -753,7 +753,8 @@ var Raster = Item.extend(/** @lends Raster# */{
 
     _draw: function(ctx, param, viewMatrix) {
         var element = this.getElement();
-        if (element) {
+        // Only draw if image is not empty (#1320).
+        if (element && element.width * element.height > 0) {
             // Handle opacity for Rasters separately from the rest, since
             // Rasters never draw a stroke. See Item#draw().
             ctx.globalAlpha = this._opacity;

--- a/test/tests/Item.js
+++ b/test/tests/Item.js
@@ -945,3 +945,9 @@ test('Children global matrices are cleared after parent transformation', functio
     group.translate(100, 0);
     equals(item.localToGlobal(item.getPointAt(0)), new Point(100, 100));
 });
+
+test('Item#rasterize() with empty bounds', function() {
+    new Path.Line([0, 0], [100, 0]).rasterize();
+    view.update();
+    expect(0);
+});


### PR DESCRIPTION
### Description
Empty raster (for example coming from path with empty bound rasterization, ...) drawing threw error.
This change prevent raster drawing in that case.
Bug is reproduced in this [sketch](http://sketch.paperjs.org/#V/0.11.8/S/q1bKS8xNVbJSCs5OLUnOUNJRSs5PAfHzUssVAhJLMvR8MvNSNaINdBQMYnUUog0NwCxNvaLE4pLUosyqVA1N65iimDygzqSi1MTsgvzMvJJiJavo2FoA) (error in console).




#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1320

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
