### PR TITLE
Fix arc drawing when points are equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix arc drawing when `from` and `to` points are equal (#1613).
 - Fix empty image drawing (#1320).
 
 ### Added

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2464,6 +2464,10 @@ new function() { // PostScript-style drawing commands
                 to = Point.read(arguments);
             } else {
                 // #3: arcTo(to, radius, rotation, clockwise, large)
+                // If from and to are equal, arc cannot be drawn (#1613).
+                if (from.equals(to)) {
+                    return;
+                }
                 // Drawing arcs in SVG style:
                 var radius = Size.read(arguments),
                     isZero = Numerical.isZero;

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -645,3 +645,11 @@ test('Path#arcTo(through, to) is on through point side (#1477)', function() {
     path.arcTo(p2, p3);
     equals(true, path.segments[1].point.x > p1.x);
 });
+
+test('Path#arcTo(to, radius, rotation, clockwise, large) when from and to are equal (#1613)', function(){
+    var point = new Point(10,10);
+    var path = new Path();
+    path.moveTo(point);
+    path.arcTo(point, new Size(10), 0, true, true);
+    expect(0);
+});


### PR DESCRIPTION
### Description

`Path#arcTo(to, radius, rotation, clockwise, large)` was throwing an
error when called with equal `from` and `to` points.
This change skips processing in that case as the arc cannot be drawn.

The bug is reproduced in this [sketch](http://sketch.paperjs.org/#V/0.11.8/S/q1bKS8xNVbJSCs5OLUnOUNJRSs5PAfEDEksyPEtSc/WSi1ITS1I11H0NDXQMDRLBpA4IGoJIdU1roJ4koJrsgvzMvJJiJavo2FoA) (error in console).



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1613, Closes #1635 
### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
