### PR TITLE
Fix PaperScript#compile() with prefix operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `PaperScript#compile()` with prefix increment/decrement operators (#1611).
 - Fix empty image drawing (#1320).
 
 ### Added

--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -268,6 +268,11 @@ Base.exports.PaperScript = function() {
                                 str = exp;
                             str = arg + '; ' + str;
                         }
+                        // If this is a prefixed update expression (++a / --a),
+                        // wrap expression in IIFE to avoid several bugs (#1450)
+                        if (node.prefix) {
+                            str = '(function(){return '+str+';})()';
+                        }
                         replaceCode(node, str);
                     } else { // AssignmentExpression
                         if (/^.=$/.test(node.operator)

--- a/test/tests/PaperScript.js
+++ b/test/tests/PaperScript.js
@@ -1,0 +1,20 @@
+/*
+ * Paper.js - The Swiss Army Knife of Vector Graphics Scripting.
+ * http://paperjs.org/
+ *
+ * Copyright (c) 2011 - 2016, Juerg Lehni & Jonathan Puckey
+ * http://scratchdisk.com/ & https://puckey.studio/
+ *
+ * Distributed under the MIT license. See LICENSE file for details.
+ *
+ * All rights reserved.
+ */
+
+QUnit.module('PaperScript');
+
+test('PaperScript#compile() with prefix increment/decrement operators', function() {
+    var code = 'var x = 1; var y = 1 * --x;';
+    var compiled = PaperScript.compile(code, paper);
+    PaperScript.execute(compiled, paper);
+    expect(0);
+});

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -63,6 +63,8 @@
 
 /*#*/ include('Numerical.js');
 
+/*#*/ include('PaperScript.js');
+
 // There is no need to test interactions in node context.
 if (!isNode) {
     /*#*/ include('Interactions.js');


### PR DESCRIPTION
### Description
PaperScript compilation was failing in some cases with prefix
increment/decrement operators.
This change wraps output expression in an IIFE to make sure it will
work in any context.
This also adds a test suite for `PaperScript` class.





#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1611

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
