### PR TITLE
Fix group color change propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix group color change propagation (#1152).
 - Fix empty image drawing (#1320).
 
 ### Added

--- a/src/style/Color.js
+++ b/src/style/Color.js
@@ -1373,3 +1373,30 @@ new function() {
          */
     });
 });
+
+/**
+ * @name LinkedColor
+ *
+ * @class An internal version of Color that notifies its owner of each change
+ * through setting itself again on the setter that corresponds to the getter
+ * that produced this LinkedColor. This is used to solve group color update
+ * problem (#1152) with the same principle used in LinkedPoint.
+ *
+ * @private
+ */
+var LinkedColor = Color.extend({
+    // Make sure LinkedColor is displayed as Color in debugger.
+    initialize: function Color(color, item, setter) {
+        // Rely on real constructor for instantiation.
+        paper.Color.apply(this, [color]);
+        // Store references.
+        this._item = item;
+        this._setter = setter;
+    },
+
+    // Rely on Color#_changed() method to detect changes.
+    _changed: function(){
+        // Update owner color by calling setter.
+        this._item[this._setter](this);
+    }
+});

--- a/src/style/Style.js
+++ b/src/style/Style.js
@@ -241,6 +241,12 @@ var Style = Base.extend(new function() {
                     }
                 }
             }
+            // Turn group related colors into LinkedColor instances that will
+            // allow calls like `group.fillColor.hue += 10` to be propagated to
+            // children.
+            if (owner instanceof Group && value instanceof Color) {
+                value = new LinkedColor(value, owner, set);
+            }
             return value;
         };
 

--- a/test/tests/Color.js
+++ b/test/tests/Color.js
@@ -299,3 +299,11 @@ test('Gradients with applyMatrix', function() {
 
     comparePixels(path, shape);
 });
+
+test('LinkedColor for group colors', function() {
+    var item = new Group(new Path(), new Path());
+    item.strokeColor = 'red';
+    item.strokeColor.hue = 50;
+    item.strokeColor.hue = 100;
+    expect(0);
+});


### PR DESCRIPTION
### Description
There was a problem when trying to change children color property trough
group getter, e.g. `group.fillColor.hue += 10`. This call was only
modifying the first child color and could lead to errors in some cases.
This change introduce a new internal class `LinkedColor` which has the
same goal as existing `LinkedPoint`: notifying its owner of any change
by setting itself as a new value.
When accessing a group related color e.g. `var color = group.fillColor`,
a `LinkedColor` instance is returned and when this instance is changed
e.g. `color.fillColor.hue += 10`, change is propagated by acting like if
we called `group.fillColor = color`.

The bug is reproduced in this [sketch](http://sketch.paperjs.org/#V/0.11.8/S/fY8xC4NADIX/SrhFhUNU6KJ06tC10PG84WoDivVO4tkOpf+9iVOHtoE8krwPHnkq7yZUtTqPGLteadWFq+x3RzBEnGAPHh9wpLDOaUutBy65nFzsU2PKotDAYjWYSmYWazP9C60+0HJDhcwaUWnJzJdIYcRDuAXi/ITwmjTfzLxfkYFd8c/llM3m3y6EbpzD4OOiamNfbw==) (error in console).



#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1152

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
