### PR TITLE
Fix for svg export multiline text

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -253,6 +253,18 @@ new function() {
     }
 
     function exportText(item) {
+        // incase text is multiline create a group
+        if (item._lines.length > 1) {
+			var nodeGroup = SvgElement.create('g');
+			for (var i in item._lines) {
+				var node = SvgElement.create('text', getTransform(item._matrix, true),
+					formatter);
+				node.setAttribute('y', 1*i + parseFloat(node.getAttribute('y')))
+				node.textContent = item._lines[i];
+				nodeGroup.appendChild(node)
+			}
+			return nodeGroup;
+		}
         var node = SvgElement.create('text', getTransform(item._matrix, true),
                 formatter);
         node.textContent = item._content;


### PR DESCRIPTION
### Description

Right now when you export a text that is broken into lines, it is rendered as a single line text. Because svg does not support line breaks, we have export each line individually

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the JSHint rules (`npm run jshint` passes)
