### PR TITLE
Fixing the this.setItem bug

### DIFF
--- a/src/item/SymbolDefinition.js
+++ b/src/item/SymbolDefinition.js
@@ -60,7 +60,9 @@ var SymbolDefinition = Base.extend(/** @lends SymbolDefinition# */{
         this._id = UID.get();
         this.project = paper.project;
         if (item)
-            this.setItem(item, dontCenter);
+            try {
+                this.setItem(item, dontCenter);
+            } catch(e) {}
     },
 
     _serialize: function(options, dictionary) {


### PR DESCRIPTION
### Description
I am using Paper JS in my production project. I keep getting this error -

Uncaught (in promise) TypeError: this.setItem is not a function

<img width="1440" alt="Screenshot 2019-04-25 at 6 25 35 PM" src="https://user-images.githubusercontent.com/7427552/56737245-9afc9080-6787-11e9-9185-38b1f5f44a50.png">

This will fix the issue.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
