### PR TITLE
Item.contains returns false when matrix not invertible instead of blowing up

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1803,8 +1803,12 @@ new function() { // Injection scope for various item event handlers
      */
     contains: function(/* point */) {
         // See CompoundPath#_contains() for the reason for !!
-        return !!this._contains(
-                this._matrix._inverseTransform(Point.read(arguments)));
+        if (this._matrix.isInvertible()) {
+            return !!this._contains(
+                    this._matrix._inverseTransform(Point.read(arguments)));
+        } else {
+            return false;
+        }
     },
 
     _contains: function(point) {

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1803,12 +1803,11 @@ new function() { // Injection scope for various item event handlers
      */
     contains: function(/* point */) {
         // See CompoundPath#_contains() for the reason for !!
-        if (this._matrix.isInvertible()) {
-            return !!this._contains(
-                    this._matrix._inverseTransform(Point.read(arguments)));
-        } else {
-            return false;
-        }
+        var matrix = this._matrix;
+        return (
+            matrix.isInvertible() && 
+            !!this._contains(matrix._inverseTransform(Point.read(arguments)))
+        );
     },
 
     _contains: function(point) {

--- a/test/tests/Item.js
+++ b/test/tests/Item.js
@@ -877,6 +877,25 @@ test('Item#pivot', function() {
             'Changing position of an item with applyMatrix = true should change pivot');
 });
 
+test('Item#contains', function() {
+    var point = new Point(50,50);
+    var path1 = new Path({matrix: new Matrix(0,0,0,0,0,0)});
+    
+    equals(path1.contains(point), false,
+            'An irregularly shaped item cannot contain a point');
+
+    var path2 = new Path.Rectangle({
+        point: [50, 50],
+        size: [100, 100]
+    });
+    equals(path2.contains(point), true,
+            'A regularly shaped item with a point inside it, contains that point');
+
+    var point2 = new Point(0,0);
+    equals(path2.contains(point2), false,
+            'A regularly shaped item with a point outside it, does not contain that point');
+});
+
 test('Item#position with irregular shape, #pivot and rotation', function() {
     var path1 = new Path([ [0, 0], [200, 100], [0, 100] ]);
     var path2 = path1.clone();


### PR DESCRIPTION
### Description
Currently, if an irregular shape is present, it can cause the following error with hover/click events:
`TypeError: Cannot read property 'isInside' of null`
It occurs because the shape is not invertible so the `_inverseTransform` fn returns null which causes the error downstream.
paper.js should return false instead of failing.

#### Related issues
Relates to https://github.com/paperjs/paper.js/pull/1156 (I believe this old PR was trying to address the same issue)

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
