### PR TITLE
Add docstring for internalBounds

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1118,6 +1118,17 @@ new function() { // Injection scope for various item event handlers
      */
 
     /**
+     * The bounding rectangle of the item without any matrix transformations.
+     *
+     * Typical use case would be drawing a frame around the object where you
+     * want to draw something of the same size, position, rotation, and scaling,
+     * like a selection frame.
+     *
+     * @name Item#internalBounds
+     * @type Rectangle
+     */
+
+    /**
      * The rough bounding rectangle of the item that is sure to include all of
      * the drawing, including stroke width.
      *


### PR DESCRIPTION
### Description

I wanted to use this feature but it wasn't in the documentation or the TypeScript specifications.

I thought adding it to the docs would make it official that this field exists and can be used without feeling like I am accessing private APIs subject to change.

I think it's very useful.  I have two use cases:

1. Drawing a selection rectangle around an object that rotates and scales to match the object
2. Positioning a textarea on top of a text item when editing it

In these cases the existing bounds properties were not helpful because they apply rotation and scaling and then calculate a rectangle that covers that area.  So if a Rectangle or PointText was rotated, the bounds just get bigger to accomodate the corners sticking out.  I want my selection rectangle to be just slightly bigger than the selected rectangle and also rotated to the same angle.  For the textarea overlay the textarea has to have the exact size and rotation of the PointText so in that case also I need to set the width and height to match the values prior to matrix application.

#### Related issues

None found.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)

Note: no new code was added, so existing tests should be fine.
