### PR TITLE
Fix node tests crash with node latest versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
-- stable
+# Stable version is temporarily disabled due to a bug in resemblejs package with
+# node v12 (https://github.com/orgs/paperjs/teams/contributors/discussions/12).
+# - stable
+- 11
 - 10
 - 8
 sudo: false
@@ -40,4 +43,4 @@ script:
 - gulp minify
 - gulp test
 - gulp zip
-- '[ "${TRAVIS_BRANCH}" = "develop" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ] && travis/deploy-prebuilt.sh || true'
+- '[ "${TRAVIS_BRANCH}" = "develop" ] && [ "${TRAVIS_NODE_VERSION}" = "11" ] && travis/deploy-prebuilt.sh || true'

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "url": "https://github.com/paperjs/paper.js"
   },
   "bugs": "https://github.com/paperjs/paper.js/issues",
-  "contributors": ["Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)", "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"],
+  "contributors": [
+    "Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)",
+    "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"
+  ],
   "main": "dist/paper-full.js",
   "types": "dist/paper.d.ts",
   "scripts": {
-    "precommit": "gulp jshint --ensure-branch develop",
-    "prepush": "gulp test --ensure-branch develop",
     "build": "gulp build",
     "dist": "gulp dist",
     "zip": "gulp zip",
@@ -23,45 +24,22 @@
     "jshint": "gulp jshint",
     "test": "gulp test"
   },
-  "files": ["AUTHORS.md", "CHANGELOG.md", "dist/", "examples/", "LICENSE.txt", "README.md"],
+  "files": [
+    "AUTHORS.md",
+    "CHANGELOG.md",
+    "dist/",
+    "examples/",
+    "LICENSE.txt",
+    "README.md"
+  ],
   "engines": {
     "node": ">=8.0.0"
   },
-  "devDependencies": {
-    "acorn": "~0.5.0",
-    "del": "^2.2.1",
-    "gulp": "^3.9.1",
-    "gulp-cached": "^1.1.0",
-    "gulp-git-streamed": "^2.8.1",
-    "gulp-jshint": "^2.0.0",
-    "gulp-json-editor": "^2.2.1",
-    "gulp-prepro": "^2.4.0",
-    "gulp-qunits": "^2.1.1",
-    "gulp-rename": "^1.2.2",
-    "gulp-shell": "^0.5.2",
-    "gulp-symlink": "^2.1.4",
-    "gulp-uglify": "^1.5.4",
-    "gulp-uncomment": "^0.3.0",
-    "gulp-util": "^3.0.7",
-    "gulp-webserver": "^0.9.1",
-    "gulp-whitespace": "^0.1.0",
-    "gulp-zip": "^3.2.0",
-    "husky": "^0.11.4",
-    "jsdom": "15.1.1",
-    "jshint": "^2.9.2",
-    "jshint-summary": "^0.4.0",
-    "merge-stream": "^1.0.0",
-    "minimist": "^1.2.0",
-    "mustache": "^3.0.1",
-    "prepro": "^2.4.0",
-    "qunitjs": "^1.23.0",
-    "require-dir": "^0.3.0",
-    "resemblejs": "3.1.0",
-    "run-sequence": "^1.2.2",
-    "source-map-support": "^0.4.0",
-    "stats.js": "0.16.0",
-    "straps": "^3.0.1",
-    "typescript": "^3.1.6"
+  "husky": {
+    "hooks": {
+      "pre-commit": "gulp jshint --ensure-branch develop",
+      "pre-push": "gulp test --ensure-branch develop"
+    }
   },
   "browser": {
     "canvas": false,
@@ -71,5 +49,58 @@
     "./dist/node/self.js": false,
     "./dist/node/extend.js": false
   },
-  "keywords": ["vector", "graphic", "graphics", "2d", "geometry", "bezier", "curve", "curves", "path", "paths", "canvas", "svg", "paper", "paper.js", "paperjs"]
+  "devDependencies": {
+    "acorn": "~0.5.0",
+    "canvas": "^2.4.1",
+    "del": "^4.1.0",
+    "gulp": "^3.9.1",
+    "gulp-cached": "^1.1.0",
+    "gulp-git-streamed": "^2.8.1",
+    "gulp-jshint": "^2.1.0",
+    "gulp-json-editor": "^2.5.2",
+    "gulp-prepro": "^2.4.0",
+    "gulp-qunits": "^2.1.2",
+    "gulp-rename": "^1.4.0",
+    "gulp-shell": "^0.7.0",
+    "gulp-symlink": "^2.1.4",
+    "gulp-uglify": "^1.5.4",
+    "gulp-uncomment": "^0.3.0",
+    "gulp-util": "^3.0.7",
+    "gulp-webserver": "^0.9.1",
+    "gulp-whitespace": "^0.1.0",
+    "gulp-zip": "^3.2.0",
+    "husky": "^2.3.0",
+    "jsdom": "^15.1.1",
+    "jshint": "^2.10.2",
+    "jshint-summary": "^0.4.0",
+    "merge-stream": "^2.0.0",
+    "minimist": "^1.2.0",
+    "mustache": "^3.0.1",
+    "prepro": "^2.4.0",
+    "qunitjs": "^1.23.0",
+    "require-dir": "^1.2.0",
+    "resemblejs": "^3.1.0",
+    "run-sequence": "^2.2.1",
+    "source-map-support": "^0.5.12",
+    "stats.js": "0.17.0",
+    "straps": "^3.0.1",
+    "typescript": "^3.1.6"
+  },
+  "keywords": [
+    "vector",
+    "graphic",
+    "graphics",
+    "2d",
+    "geometry",
+    "bezier",
+    "curve",
+    "curves",
+    "path",
+    "paths",
+    "canvas",
+    "svg",
+    "paper",
+    "paper.js",
+    "paperjs"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
     "url": "https://github.com/paperjs/paper.js"
   },
   "bugs": "https://github.com/paperjs/paper.js/issues",
-  "contributors": [
-    "Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)",
-    "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"
-  ],
+  "contributors": ["Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)", "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"],
   "main": "dist/paper-full.js",
   "types": "dist/paper.d.ts",
   "scripts": {
+    "precommit": "gulp jshint --ensure-branch develop",
+    "prepush": "gulp test --ensure-branch develop",
     "build": "gulp build",
     "dist": "gulp dist",
     "zip": "gulp zip",
@@ -24,22 +23,45 @@
     "jshint": "gulp jshint",
     "test": "gulp test"
   },
-  "files": [
-    "AUTHORS.md",
-    "CHANGELOG.md",
-    "dist/",
-    "examples/",
-    "LICENSE.txt",
-    "README.md"
-  ],
+  "files": ["AUTHORS.md", "CHANGELOG.md", "dist/", "examples/", "LICENSE.txt", "README.md"],
   "engines": {
     "node": ">=8.0.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "gulp jshint --ensure-branch develop",
-      "pre-push": "gulp test --ensure-branch develop"
-    }
+  "devDependencies": {
+    "acorn": "~0.5.0",
+    "del": "^2.2.1",
+    "gulp": "^3.9.1",
+    "gulp-cached": "^1.1.0",
+    "gulp-git-streamed": "^2.8.1",
+    "gulp-jshint": "^2.0.0",
+    "gulp-json-editor": "^2.2.1",
+    "gulp-prepro": "^2.4.0",
+    "gulp-qunits": "^2.1.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.5.2",
+    "gulp-symlink": "^2.1.4",
+    "gulp-uglify": "^1.5.4",
+    "gulp-uncomment": "^0.3.0",
+    "gulp-util": "^3.0.7",
+    "gulp-webserver": "^0.9.1",
+    "gulp-whitespace": "^0.1.0",
+    "gulp-zip": "^3.2.0",
+    "husky": "^0.11.4",
+    "jsdom": "15.1.1",
+    "jshint": "^2.9.2",
+    "jshint-summary": "^0.4.0",
+    "merge-stream": "^1.0.0",
+    "minimist": "^1.2.0",
+    "mustache": "^3.0.1",
+    "prepro": "^2.4.0",
+    "qunitjs": "^1.23.0",
+    "require-dir": "^0.3.0",
+    "resemblejs": "3.1.0",
+    "run-sequence": "^1.2.2",
+    "source-map-support": "^0.4.0",
+    "stats.js": "0.16.0",
+    "straps": "^3.0.1",
+    "typescript": "^3.1.6"
   },
   "browser": {
     "canvas": false,
@@ -49,58 +71,5 @@
     "./dist/node/self.js": false,
     "./dist/node/extend.js": false
   },
-  "devDependencies": {
-    "acorn": "~0.5.0",
-    "canvas": "^2.4.1",
-    "del": "^4.1.0",
-    "gulp": "^3.9.1",
-    "gulp-cached": "^1.1.0",
-    "gulp-git-streamed": "^2.8.1",
-    "gulp-jshint": "^2.1.0",
-    "gulp-json-editor": "^2.5.2",
-    "gulp-prepro": "^2.4.0",
-    "gulp-qunits": "^2.1.2",
-    "gulp-rename": "^1.4.0",
-    "gulp-shell": "^0.7.0",
-    "gulp-symlink": "^2.1.4",
-    "gulp-uglify": "^1.5.4",
-    "gulp-uncomment": "^0.3.0",
-    "gulp-util": "^3.0.7",
-    "gulp-webserver": "^0.9.1",
-    "gulp-whitespace": "^0.1.0",
-    "gulp-zip": "^3.2.0",
-    "husky": "^2.3.0",
-    "jsdom": "^15.1.1",
-    "jshint": "^2.10.2",
-    "jshint-summary": "^0.4.0",
-    "merge-stream": "^2.0.0",
-    "minimist": "^1.2.0",
-    "mustache": "^3.0.1",
-    "prepro": "^2.4.0",
-    "qunitjs": "^1.23.0",
-    "require-dir": "^1.2.0",
-    "resemblejs": "^3.1.0",
-    "run-sequence": "^2.2.1",
-    "source-map-support": "^0.5.12",
-    "stats.js": "0.17.0",
-    "straps": "^3.0.1",
-    "typescript": "^3.1.6"
-  },
-  "keywords": [
-    "vector",
-    "graphic",
-    "graphics",
-    "2d",
-    "geometry",
-    "bezier",
-    "curve",
-    "curves",
-    "path",
-    "paths",
-    "canvas",
-    "svg",
-    "paper",
-    "paper.js",
-    "paperjs"
-  ]
+  "keywords": ["vector", "graphic", "graphics", "2d", "geometry", "bezier", "curve", "curves", "path", "paths", "canvas", "svg", "paper", "paper.js", "paperjs"]
 }

--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -110,7 +110,6 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             // `agent.node` is expected to be true in node context.
             if (agent.jsdom) {
                 agent.node = true;
-                delete agent.jsdom;
             }
         }
     },

--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -87,7 +87,7 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
             // here: { chrome: true, webkit: false }, Mozilla missing is the
             // only difference to jQuery.browser
             user.replace(
-                /(opera|chrome|safari|webkit|firefox|msie|trident|atom|node)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:v?([.\d]+))?/g,
+                /(opera|chrome|safari|webkit|firefox|msie|trident|atom|node|jsdom)\/?\s*([.\d]+)(?:.*version\/([.\d]+))?(?:.*rv\:v?([.\d]+))?/g,
                 function(match, n, v1, v2, rv) {
                     // Do not set additional browsers once chrome is detected.
                     if (!agent.chrome) {
@@ -105,6 +105,13 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
                 delete agent.webkit;
             if (agent.atom)
                 delete agent.chrome;
+            // In node context, JSDOM user agent no longer include "node" word,
+            // it is now called "jsdom". So we need to replace it because
+            // `agent.node` is expected to be true in node context.
+            if (agent.jsdom) {
+                agent.node = true;
+                delete agent.jsdom;
+            }
         }
     },
 

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -408,8 +408,9 @@ var Raster = Item.extend(/** @lends Raster# */{
             crossOrigin = this._crossOrigin;
         if (crossOrigin)
             image.crossOrigin = crossOrigin;
-        // We need to avoid setting image source to null, otherwise an unwanted
-        // error would be thrown in node context.
+        // Prevent setting image source to `null`, as this isn't supported by browsers,
+        // and it would actually throw exceptions in JSDOM.
+        //TODO: Look into fixing this exception in JSDOM
         if (src)
             image.src = src;
         this.setImage(image);

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -408,6 +408,8 @@ var Raster = Item.extend(/** @lends Raster# */{
             crossOrigin = this._crossOrigin;
         if (crossOrigin)
             image.crossOrigin = crossOrigin;
+        // We need to avoid setting image source to null, otherwise an unwanted
+        // error would be thrown in node context.
         if (src)
             image.src = src;
         this.setImage(image);

--- a/src/node/canvas.js
+++ b/src/node/canvas.js
@@ -18,7 +18,7 @@
 module.exports = function(self, requireName) {
     var Canvas;
     try {
-        Canvas = require('canvas');
+        Canvas = require('canvas').Canvas;
     } catch(error) {
         // Remove `self.window`, so we still have the global `self` reference,
         // but no `window` object:

--- a/src/node/self.js
+++ b/src/node/self.js
@@ -37,25 +37,13 @@ try {
 if (jsdom) {
     // Create our document and window objects through jsdom.
     /* global document:true, window:true */
-    var html = '<html><body></body></html>',
-        options = {
-            // Use the current working directory as the document's origin, so
-            // requests to local files work correctly with CORS.
-            url: 'file://' + process.cwd() + '/',
-            // Old JSDOM:
-            features: {
-                FetchExternalResources: ['img', 'script']
-            },
-            // New JSDOM:
-            resources: 'usable'
-        };
-    if (jsdom.JSDOM) {
-        var dom = new jsdom.JSDOM(html, options);
-        self = dom.window;
-    } else {
-        var document = jsdom.jsdom(html, options);
-        self = document.defaultView;
-    }
+    var document = new jsdom.JSDOM('<html><body></body></html>', {
+        // Use the current working directory as the document's origin, so
+        // requests to local files work correctly with CORS.
+        url: 'file://' + process.cwd() + '/',
+        resources: 'usable'
+    });
+    self = document.window;
     require('./canvas.js')(self, requireName);
     require('./xml.js')(self);
 } else {


### PR DESCRIPTION
### Description
`canvas` package v1 was no longer compatible with node v11 & v12.
As it was a dependency of both `jsdom` and `resemblejs`, this commit updates these packages to their latest versions which work with `canvas` v2.
As these updates include some API breaking changes, this commit also updates `paper` code accordingly.

### Checklist
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
