### PR TITLE
Fix SVG linear gradient import x2 default value.

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -174,7 +174,14 @@ new function() {
             highlight = getPoint(node, 'fx', 'fy', true, scaleToBounds);
         } else {
             origin = getPoint(node, 'x1', 'y1', false, scaleToBounds);
-            destination = getPoint(node, 'x2', 'y2', false, scaleToBounds);
+            // As SVG spec states, x2 default value should be `100%`:
+            // https://www.w3.org/TR/SVG11/pservers.html#LinearGradients
+            // so we manually parse each attribute instead of using getPoint().
+            var x2 = node.hasAttribute('x2')
+                ? getValue(node, 'x2', false, false, scaleToBounds)
+                : rootSize.width;
+            var y2 = getValue(node, 'y2', false, false, scaleToBounds);
+            destination = new Point(x2, y2);
         }
         var color = applyAttributes(
                 new Color(gradient, origin, destination, highlight), node);

--- a/test/assets/gradients-3.svg
+++ b/test/assets/gradients-3.svg
@@ -1,0 +1,9 @@
+<svg x="0" y="0" width="300" height="300" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="gradient" x1="0" y1="0" y2="300" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="yellow"></stop>
+            <stop offset="1" stop-color="blue"></stop>
+        </linearGradient>
+    </defs>
+    <rect x="0" y="0" width="300" height="300" fill="url(#gradient)"></rect>
+</svg>

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,11 +10,13 @@
  * All rights reserved.
  */
 
-var isNode = typeof global === 'object',
+// We call our variable `isNodeContext` because resemblejs exposes a global
+// `isNode` function which would override it and break node check.
+var isNodeContext = typeof global === 'object',
     isPhantom = typeof window === 'object' && !!window.callPhantom,
     scope;
 
-if (isNode) {
+if (isNodeContext) {
     scope = global;
     // Resemble.js needs the Image constructor global.
     global.Image = paper.window.Image;
@@ -36,7 +38,7 @@ if (isNode) {
 
 // Some native javascript classes have name collisions with Paper.js classes.
 // If they have not already been stored in src/load.js, we dot it now.
-if (!isNode && typeof NativeClasses === 'undefined')
+if (!isNodeContext && typeof NativeClasses === 'undefined')
 {
     NativeClasses = {
         Event: Event,
@@ -215,7 +217,7 @@ var compareImageData = function(imageData1, imageData2, tolerance, diffDetail) {
         detail += diffDetail;
     }
     QUnit.push(ok, text, (100).toFixed(fixed) + '% identical');
-    if (!ok && result && !isNode) {
+    if (!ok && result && !isNodeContext) {
         // Get the right entry for this unit test and assertion, and
         // replace the results with images
         var entry = document.getElementById('qunit-test-output-' + id)

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -113,7 +113,7 @@ test('Export SVG path at precision 0', function() {
     equals(path.exportSVG({ precision: 0 }).getAttribute('d'), 'M0,2l1,1');
 });
 
-if (!isNode) {
+if (!isNodeContext) {
     // JSDom does not have SVG rendering, so we can't test there.
     test('Export transformed shapes', function(assert) {
         var rect = new Shape.Rectangle({

--- a/test/tests/SvgImport.js
+++ b/test/tests/SvgImport.js
@@ -165,8 +165,7 @@ function importSVG(assert, url, message, options) {
         }
     });
 }
-
-if (!isNode) {
+if (!isNodeContext) {
     // JSDom does not have SVG rendering, so we can't test there.
     var svgFiles = {
         'butterfly': { tolerance: 1e-2 },
@@ -176,7 +175,8 @@ if (!isNode) {
         'symbol': {},
         'symbols': {},
         'blendModes': {},
-        'gradients-1': {}
+        'gradients-1': {},
+        'gradients-3': {}
     };
     // TODO: Investigate why Phantom struggles with this file:
     if (!isPhantom)

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -64,6 +64,6 @@
 /*#*/ include('Numerical.js');
 
 // There is no need to test interactions in node context.
-if (!isNode) {
+if (!isNodeContext) {
     /*#*/ include('Interactions.js');
 }


### PR DESCRIPTION
### Description
As for SVG spec, linear gradient `x2` default value should be `100%`.
This commit also include a rename of the internal variable `isNode`, used in test, to `isNodeContext`.
This was needed because the new version of `resemblejs` exposes a `isNode` function which was conflicting with it.

#### Related issues
- Closes #1660 

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
