### PR TITLE
Fix item.clipMask documentation

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -658,8 +658,8 @@ new function() { // Injection scope for various item event handlers
 
     /**
      * Specifies whether the item defines a clip mask. This can only be set on
-     * paths, compound paths, and text frame objects, and only if the item is
-     * already contained within a clipping group.
+     * paths and compound paths, and only if the item is already contained
+     * within a clipping group.
      *
      * @bean
      * @type Boolean


### PR DESCRIPTION
### Description
Texts are not currently supported as clip masks.


#### Related issues
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/paperjs/JDS6WUvc6jE/jpL5l4j8BwAJ

### Checklist
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
