### PR TITLE
Add support for nullable in documentation

### DIFF
--- a/src/anim/Tween.js
+++ b/src/anim/Tween.js
@@ -265,7 +265,7 @@ var Tween = Base.extend(Emitter, /** @lends Tween# */{
      *
      * @name Tween#onUpdate
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Display tween progression values:

--- a/src/item/HitResult.js
+++ b/src/item/HitResult.js
@@ -75,7 +75,7 @@ var HitResult = Base.extend(/** @lends HitResult# */{
      *
      * @name HitResult#color
      * @property
-     * @type Color
+     * @type ?Color
      */
 
     /**

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -3081,7 +3081,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#strokeColor
      * @property
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Setting the stroke color of a path:
@@ -3243,7 +3243,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#fillColor
      * @property
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Setting the fill color of a path to red:
@@ -3277,7 +3277,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @property
      * @name Item#shadowColor
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Creating a circle with a black shadow:
@@ -3323,7 +3323,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#selectedColor
      * @property
-     * @type Color
+     * @type ?Color
      */
 }, Base.each(['rotate', 'scale', 'shear', 'skew'], function(key) {
     var rotate = key === 'rotate';
@@ -3769,7 +3769,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onFrame
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onFrame
      *
      * @example {@paperscript}
@@ -3796,7 +3796,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseDown
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseDown
      *
      * @example {@paperscript}
@@ -3846,7 +3846,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseDrag
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseDrag
      *
      * @example {@paperscript height=240}
@@ -3875,7 +3875,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseUp
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseUp
      *
      * @example {@paperscript}
@@ -3905,7 +3905,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onClick
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onClick
      *
      * @example {@paperscript}
@@ -3955,7 +3955,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onDoubleClick
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onDoubleClick
      *
      * @example {@paperscript}
@@ -4005,7 +4005,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseMove
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseMove
      *
      * @example {@paperscript}
@@ -4036,7 +4036,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseEnter
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseEnter
      *
      * @example {@paperscript}
@@ -4098,7 +4098,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#onMouseLeave
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseLeave
      *
      * @example {@paperscript}

--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -763,7 +763,7 @@ var Raster = Item.extend(/** @lends Raster# */{
      *
      * @name Raster#onLoad
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example
      * var url = 'http://assets.paperjs.org/images/marilyn.jpg';
@@ -789,7 +789,7 @@ var Raster = Item.extend(/** @lends Raster# */{
      *
      * @name Raster#onError
      * @property
-     * @type Function
+     * @type ?Function
      */
 
     _getBounds: function(matrix, options) {

--- a/src/style/Style.js
+++ b/src/style/Style.js
@@ -411,7 +411,7 @@ var Style = Base.extend(new function() {
      *
      * @name Style#strokeColor
      * @property
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Setting the stroke color of a path:
@@ -568,7 +568,7 @@ var Style = Base.extend(new function() {
      *
      * @name Style#fillColor
      * @property
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Setting the fill color of a path to red:
@@ -599,7 +599,7 @@ var Style = Base.extend(new function() {
      *
      * @property
      * @name Style#shadowColor
-     * @type Color
+     * @type ?Color
      *
      * @example {@paperscript}
      * // Creating a circle with a black shadow:
@@ -643,7 +643,7 @@ var Style = Base.extend(new function() {
      *
      * @name Style#selectedColor
      * @property
-     * @type Color
+     * @type ?Color
      */
 
     /**

--- a/src/tool/Tool.js
+++ b/src/tool/Tool.js
@@ -135,7 +135,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onMouseDown
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Creating circle shaped paths where the user presses the mouse button:
@@ -157,7 +157,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onMouseDrag
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Draw a line by adding a segment to a path on every mouse drag event:
@@ -180,7 +180,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onMouseMove
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Moving a path to the position of the mouse:
@@ -206,7 +206,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onMouseUp
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Creating circle shaped paths where the user releases the mouse:
@@ -234,7 +234,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onKeyDown
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example {@paperscript}
      * // Scaling a path whenever the user presses the space bar:
@@ -268,7 +268,7 @@ var Tool = PaperScopeItem.extend(/** @lends Tool# */{
      *
      * @name Tool#onKeyUp
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example
      * tool.onKeyUp = function(event) {

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -746,7 +746,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onFrame
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onFrame
      *
      * @example {@paperscript}
@@ -768,7 +768,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onResize
      * @property
-     * @type Function
+     * @type ?Function
      *
      * @example
      * // Repositioning items when a view is resized:
@@ -793,7 +793,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseDown
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onMouseDown
      */
 
@@ -807,7 +807,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseDrag
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onMouseDrag
      */
 
@@ -818,7 +818,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseUp
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onMouseUp
      */
 
@@ -832,7 +832,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onClick
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onClick
      */
 
@@ -846,7 +846,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onDoubleClick
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onDoubleClick
      */
 
@@ -860,7 +860,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseMove
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onMouseMove
      */
 
@@ -875,7 +875,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseEnter
      * @property
-     * @type Function
+     * @type ?Function
      * @see Item#onMouseEnter
      */
 
@@ -889,7 +889,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#onMouseLeave
      * @property
-     * @type Function
+     * @type ?Function
      * @see View#onMouseLeave
      */
 


### PR DESCRIPTION
### Description
The goal was mainly to improve the generated typescript definition by only declaring a property nullable when it really is.
This adds support for `?Type` as nullable type syntax in JSDoc parser.
This also declares some nullable properties in the doc.
I only found cases where it made sense for `Color` and `Function` types but there might be others that I missed.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Depends on https://github.com/paperjs/jsdoc/pull/8 merge
- Relates to https://github.com/paperjs/paper.js/issues/1664

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
