### PR TITLE
Fix SymbolItem#hitTestAll

### DIFF
--- a/src/item/SymbolItem.js
+++ b/src/item/SymbolItem.js
@@ -121,7 +121,16 @@ var SymbolItem = Item.extend(/** @lends SymbolItem# */{
     },
 
     _hitTestSelf: function(point, options, viewMatrix) {
+        // We need to call definition item hit test with `options.all`
+        // disabled, otherwise it would populate the array with its own
+        // matches. What we want instead is only returning one match per symbol
+        // item (#1680). So we store original matches array...
+        var all = options.all;
+        // ...we temporarily disable `options.all`...
+        delete options.all;
         var res = this._definition._item._hitTest(point, options, viewMatrix);
+        // ...then after hit testing, we restore the original matches array.
+        options.all = all;
         // TODO: When the symbol's definition is a path, should hitResult
         // contain information like HitResult#curve?
         if (res)

--- a/test/tests/SymbolItem.js
+++ b/test/tests/SymbolItem.js
@@ -143,3 +143,18 @@ test('SymbolItem#bounds with #applyMatrix = false', function() {
     equals(function() { return placed.bounds; },
         { x: 150, y: 150, width: 100, height: 100 });
 });
+
+test('SymbolItem#hitTestAll', function() {
+    var symbol = new SymbolDefinition(
+        new Path.Circle({
+            center: [0, 0],
+            radius: 10,
+            fillColor: 'orange'
+        })
+    );
+    var symbolItem = symbol.place([50, 50]);
+
+    var hitTestAll = symbolItem.hitTestAll([50, 50]);
+    equals(hitTestAll.length, 1);
+    equals(hitTestAll[0].item.id, symbolItem.id);
+});


### PR DESCRIPTION
### Description
`symbolItem.hitTestAll()` was wrongly returning the result of its symbol definition hit test in addition to its own hit test.
The bug can be reduced to this [sketch](http://sketch.paperjs.org/#V/0.12.3/S/XVDNCsIwDH6V0osbjDEPXiYeRC/eBL3NHWqNrpgl0lZFxHe3VebUHEK+PxJyl6RakKVcHcHrRmZS8y7ii7LC3doto5gIgqtYvcAc9oaMN0zJxm5IhIriUvkmnxmrEZJ7J8TSQB5sKaoiE0WdfUtW7czZlWJY/NB7gzhj5BAasFV0gEEnP9I4pePY+/sWHtpw4xvkJ1QakmoU9o2K+u3t/I3xa3B+ivjxx3De839BzeQYIUc+JL0pHYc3bS2o44kNeSfLqn48AQ==).

    var symbol = new SymbolDefinition(
        new Path.Circle({
            center: [0, 0],
            radius: 10,
            fillColor: 'orange'
        })
    );
    var symbolItem = symbol.place([50, 50]);
    
    var hitTestAll = symbolItem.hitTestAll([50, 50]);
    console.log(hitTestAll);

Only one hit should be logged to the console (instead of 2).

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1680

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
