### PR TITLE
Replace gulp-util to recommended packages

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -11,7 +11,6 @@
  */
 
 var gulp = require('gulp'),
-    gutil = require('gulp-util'),
     qunits = require('gulp-qunits'),
     webserver = require('gulp-webserver');
 

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -12,14 +12,15 @@
 
 var gulp = require('gulp'),
     path = require('path'),
-    gutil = require('gulp-util');
+    log = require('fancy-log'),
+    colors = require('ansi-colors');
 
 gulp.task('watch', function () {
     gulp.watch('src/**/*.js', ['jshint'])
         .on('change', function(event) {
-            gutil.log(
-                gutil.colors.green('File ' + event.type + ': ') +
-                gutil.colors.magenta(path.basename(event.path))
+            log(
+                colors.green('File ' + event.type + ': ') +
+                colors.magenta(path.basename(event.path))
             );
         });
 });

--- a/gulp/utils/error.js
+++ b/gulp/utils/error.js
@@ -11,8 +11,9 @@
  */
 
 var gulp = require('gulp'),
-    gutil = require('gulp-util'),
-    ERROR = gutil.colors.red('[ERROR]');
+    log = require('fancy-log'),
+    colors = require('ansi-colors'),
+    ERROR = colors.red('[ERROR]');
 
 gulp.on('error', function(err) {
     var msg = err.toString();
@@ -21,7 +22,7 @@ gulp.on('error', function(err) {
     if (err.stack)
         msg += err.stack;
     msg.split(/\r\n|\n|\r/mg).forEach(function(line) {
-        gutil.log(ERROR, line);
+        log(ERROR, line);
     });
     this.emit('end');
 });

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
   },
   "devDependencies": {
     "acorn": "~0.5.0",
+    "ansi-colors": "^4.1.1",
     "canvas": "^2.4.1",
     "del": "^4.1.0",
+    "fancy-log": "^1.3.3",
     "gulp": "^3.9.1",
     "gulp-cached": "^1.1.0",
     "gulp-git-streamed": "^2.8.1",
@@ -55,7 +57,6 @@
     "gulp-symlink": "^2.1.4",
     "gulp-uglify": "^1.5.4",
     "gulp-uncomment": "^0.3.0",
-    "gulp-util": "^3.0.7",
     "gulp-webserver": "^0.9.1",
     "gulp-whitespace": "^0.1.0",
     "gulp-zip": "^3.2.0",


### PR DESCRIPTION
Replacement of gulp-util is recommended.
https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
