### PR TITLE
Add stable node version to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 # Follow https://github.com/nodejs/LTS to decide when to remove a version
 node_js:
-# Stable version is temporarily disabled due to a bug in resemblejs package with
-# node v12 (https://github.com/orgs/paperjs/teams/contributors/discussions/12).
-# - stable
+- stable
 - 11
 - 10
 - 8
@@ -36,11 +34,10 @@ install:
 before_script:
 - travis/setup-git.sh
 - npm set progress=false
-- which gulp || npm install -g gulp-cli
 - npm install
 script:
-- gulp jshint
-- gulp minify
-- gulp test
-- gulp zip
+- npm run jshint
+- npm run minify
+- npm run test
+- npm run zip
 - '[ "${TRAVIS_BRANCH}" = "develop" ] && [ "${TRAVIS_NODE_VERSION}" = "11" ] && travis/deploy-prebuilt.sh || true'

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     prepro = require('gulp-prepro'),
     rename = require('gulp-rename'),
     uncomment = require('gulp-uncomment'),

--- a/gulp/tasks/dist.js
+++ b/gulp/tasks/dist.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     del = require('del'),
     merge = require('merge-stream'),
     zip = require('gulp-zip');

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -10,12 +10,12 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     del = require('del'),
     rename = require('gulp-rename'),
     shell = require('gulp-shell'),
     options = require('../utils/options.js'),
-    run = require('run-sequence');
+    run = require('run-sequence-v3');
 
 var docOptions = {
     local: 'docs', // Generates the offline docs

--- a/gulp/tasks/jshint.js
+++ b/gulp/tasks/jshint.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     jshint = require('gulp-jshint'),
     cache = require('gulp-cached');
 

--- a/gulp/tasks/load.js
+++ b/gulp/tasks/load.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     del = require('del'),
     symlink = require('gulp-symlink');
 

--- a/gulp/tasks/minify.js
+++ b/gulp/tasks/minify.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     rename = require('gulp-rename'),
     fs = require('fs'),
     uglify = require('gulp-uglify');

--- a/gulp/tasks/publish.js
+++ b/gulp/tasks/publish.js
@@ -10,11 +10,11 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     path = require('path'),
     fs = require('fs'),
     del = require('del'),
-    run = require('run-sequence'),
+    run = require('run-sequence-v3'),
     git = require('gulp-git-streamed'),
     shell = require('gulp-shell'),
     merge = require('merge-stream'),

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     gutil = require('gulp-util'),
     qunits = require('gulp-qunits'),
     webserver = require('gulp-webserver');

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     path = require('path'),
     gutil = require('gulp-util');
 

--- a/gulp/utils/error.js
+++ b/gulp/utils/error.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     gutil = require('gulp-util'),
     ERROR = gutil.colors.red('[ERROR]');
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@
  * All rights reserved.
  */
 
-var gulp = require('gulp'),
+var gulp = require('gulp-v3'),
     requireDir = require('require-dir');
 
 requireDir('./gulp/utils');

--- a/package.json
+++ b/package.json
@@ -9,11 +9,15 @@
     "url": "https://github.com/paperjs/paper.js"
   },
   "bugs": "https://github.com/paperjs/paper.js/issues",
-  "contributors": ["Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)", "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"],
+  "contributors": [
+    "Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)",
+    "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"
+  ],
   "main": "dist/paper-full.js",
   "types": "dist/paper.d.ts",
   "scripts": {
     "build": "gulp build",
+    "minify": "gulp minify",
     "dist": "gulp dist",
     "zip": "gulp zip",
     "docs": "gulp docs",
@@ -21,7 +25,14 @@
     "jshint": "gulp jshint",
     "test": "gulp test"
   },
-  "files": ["AUTHORS.md", "CHANGELOG.md", "dist/", "examples/", "LICENSE.txt", "README.md"],
+  "files": [
+    "AUTHORS.md",
+    "CHANGELOG.md",
+    "dist/",
+    "examples/",
+    "LICENSE.txt",
+    "README.md"
+  ],
   "engines": {
     "node": ">=8.0.0"
   },
@@ -43,7 +54,6 @@
     "acorn": "~0.5.0",
     "canvas": "^2.4.1",
     "del": "^4.1.0",
-    "gulp": "^3.9.1",
     "gulp-cached": "^1.1.0",
     "gulp-git-streamed": "^2.8.1",
     "gulp-jshint": "^2.1.0",
@@ -56,6 +66,7 @@
     "gulp-uglify": "^1.5.4",
     "gulp-uncomment": "^0.3.0",
     "gulp-util": "^3.0.7",
+    "gulp-v3": "^3.12.1",
     "gulp-webserver": "^0.9.1",
     "gulp-whitespace": "^0.1.0",
     "gulp-zip": "^3.2.0",
@@ -70,11 +81,27 @@
     "qunitjs": "^1.23.0",
     "require-dir": "^1.2.0",
     "resemblejs": "^3.1.0",
-    "run-sequence": "^2.2.1",
+    "run-sequence-v3": "^2.3.0",
     "source-map-support": "^0.5.12",
     "stats.js": "0.17.0",
     "straps": "^3.0.1",
     "typescript": "^3.1.6"
   },
-  "keywords": ["vector", "graphic", "graphics", "2d", "geometry", "bezier", "curve", "curves", "path", "paths", "canvas", "svg", "paper", "paper.js", "paperjs"]
+  "keywords": [
+    "vector",
+    "graphic",
+    "graphics",
+    "2d",
+    "geometry",
+    "bezier",
+    "curve",
+    "curves",
+    "path",
+    "paths",
+    "canvas",
+    "svg",
+    "paper",
+    "paper.js",
+    "paperjs"
+  ]
 }


### PR DESCRIPTION
gulp@3 is not working in node v12 as reported in https://github.com/gulpjs/gulp/issues/2324.
Upgrade to gulp@4 would be the best way, but it will take time.
Thus, I replace to [gulp-v3](https://github.com/sapics/gulp-v3) and [run-sequence-v3](https://github.com/sapics/run-sequence-v3) which are working in node v12, because it is very easy :)
If someone upgrade to gulp@4, please throw this PR away 👍 

ADD: Now travis report some errors, it would come from cache, because [my travis is green in same repository](https://travis-ci.org/sapics/paper.js/builds/571201927).