### PR TITLE
Fix shape bounds when passing position in constructor

### DIFF
--- a/src/item/Shape.js
+++ b/src/item/Shape.js
@@ -101,8 +101,8 @@ var Shape = Item.extend(/** @lends Shape# */{
                 this._radius._set(width / 2, height / 2);
             }
             this._size._set(width, height);
-            this._changed(/*#=*/Change.GEOMETRY);
         }
+        this._changed(/*#=*/Change.GEOMETRY);
     },
 
     /**

--- a/test/tests/Shape.js
+++ b/test/tests/Shape.js
@@ -53,3 +53,11 @@ test('shape.toPath().toShape()', function() {
         equals(shape.toPath().toShape(), shape, name + '.toPath().toShape()');
     });
 });
+
+test('new Shape.Rectangle() with position set before size', function() {
+    var shape1 = new Shape.Rectangle({
+        position: [0, 0],
+        size: new Size(100, 100)
+    });
+    equals(shape1.bounds.width, 100);
+});


### PR DESCRIPTION
### Description

In some special circumstances, when position was passed in constructor and when position key was set before size key, bounds were wrongly calculated.
This ensure that when size is set, even the first time, bounds are properly recalculated.

Here is a minimal reproduction [sketch](http://sketch.paperjs.org/#V/0.12.3/S/PU7LCoMwEPyVJRcVQtBrpD9Rj+ohJosG00RMrKXivzfpa2Efs8MwcxArbkg4aWYMciKUSKcSls76AH4SC1ZwAYs7NAmwK8og7GgwP7q1sxBrcV4H7SyHtqRQ9vRHeP1E/tHGK6/KSMdRJP4s6rRSJy9nkBk35hk+luiACu7CbBit3yohwybM/5fRbzQ2uM0qz3atwlTUMf+wopgXp23whLf9+QI=).

    const shape1 = new Shape.Rectangle({
        position: [0, 0],
        size: new Size(100, 100)
    });
    
    console.log('expected value = 100, actual value = ', shape1.bounds.width);


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1686

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
