### PR TITLE
feat: allows import core version in typescript

### DIFF
--- a/dist/paper-core.d.ts
+++ b/dist/paper-core.d.ts
@@ -1,2 +1,1 @@
-import paper from 'paper';
-export default paper;
+import 'paper';

--- a/dist/paper-core.d.ts
+++ b/dist/paper-core.d.ts
@@ -1,0 +1,2 @@
+import paper from 'paper';
+export default paper;

--- a/gulp/tasks/dist.js
+++ b/gulp/tasks/dist.js
@@ -23,6 +23,7 @@ gulp.task('zip', ['clean:zip', 'dist'], function() {
                 'dist/paper-full*.js',
                 'dist/paper-core*.js',
                 'dist/paper.d.ts',
+                'dist/paper-core.d.ts',
                 'dist/node/**/*',
                 'LICENSE.txt',
                 'examples/**/*',

--- a/gulp/typescript/typescript-definition-template.mustache
+++ b/gulp/typescript/typescript-definition-template.mustache
@@ -68,3 +68,6 @@ declare module paper {
 declare module 'paper' {
     export = paper
 }
+declare module 'paper/dist/paper-core' {
+    export = paper
+}


### PR DESCRIPTION
### Description

Allows typescript users to import core version of paper as `import paper from 'paper/dist/paper-core';`

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the JSHint rules (`npm run jshint` passes)
