### PR TITLE
Fix: nested group matrix should not be reset

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -3549,24 +3549,25 @@ new function() { // Injection scope for hit-test functions shared with project
             if (strokeColor)
                 strokeColor.transform(matrix);
         }
-        // Call #_transformContent() now, if we need to directly apply the
-        // internal _matrix transformations to the item's content.
-        // Application is not possible on Raster, PointText, SymbolItem, since
-        // the matrix is where the actual transformation state is stored.
-        if (applyMatrix && (applyMatrix = this._transformContent(_matrix,
-                _applyRecursively, _setApplyMatrix))) {
-            // Pivot is provided in the parent's coordinate system, so transform
-            // it along too.
-            var pivot = this._pivot;
-            if (pivot)
-                _matrix._transformPoint(pivot, pivot, true);
-            // Reset the internal matrix to the identity transformation if
-            // it was possible to apply it, but do not notify owner of change.
-            _matrix.reset(true);
-            // Set the internal _applyMatrix flag to true if we're told to
-            // do so
+        if (applyMatrix) {
+            // Set the internal _applyMatrix flag to true if we're told to do so.
             if (_setApplyMatrix && this._canApplyMatrix)
                 this._applyMatrix = true;
+            // Call #_transformContent() now, if we need to directly apply the
+            // internal _matrix transformations to the item's content.
+            // Application is not possible on Raster, PointText, SymbolItem, since
+            // the matrix is where the actual transformation state is stored.
+            if (this._applyMatrix && (applyMatrix = this._transformContent(_matrix,
+                    _applyRecursively, _setApplyMatrix))) {
+                // Pivot is provided in the parent's coordinate system, so transform
+                // it along too.
+                var pivot = this._pivot;
+                if (pivot)
+                    _matrix._transformPoint(pivot, pivot, true);
+                // Reset the internal matrix to the identity transformation if
+                // it was possible to apply it, but do not notify owner of change.
+                _matrix.reset(true);
+            }
         }
         // Calling _changed will clear _bounds and _position, but depending
         // on matrix we can calculate and set them again, so preserve them.

--- a/test/tests/Group.js
+++ b/test/tests/Group.js
@@ -189,3 +189,13 @@ test(
         equals(group.internalBounds, expected);
     }
 );
+
+test('group.matrix with parent matrix applied (#1711)', function() {
+    var child = new Group({ applyMatrix: false });
+    var parent = new Group([child]);
+    var scale = 1.1;
+    var initial = child.scaling.x;
+    parent.scale(scale);
+    var final = child.scaling.x;
+    equals(final, initial * scale);
+});


### PR DESCRIPTION
### Description
When a group had `applyMatrix` set to `false`, when its parent's matrix was applied, its matrix was applied to its children then it was reset.
This makes sure that in this case, parent matrix is only added to child matrix but not applied to child's children and that child's matrix is not reset.

#### Related issues
- Closes #1711

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
