### PR TITLE
Fix handling of negative Shape.Rectangle sizes

### DIFF
--- a/src/item/Shape.js
+++ b/src/item/Shape.js
@@ -90,7 +90,7 @@ var Shape = Item.extend(/** @lends Shape# */{
                 height = size.height;
             if (type === 'rectangle') {
                 // Shrink radius accordingly
-                this._radius.set(Size.min(this._radius, size.divide(2)));
+                this._radius.set(Size.min(this._radius, size.divide(2).abs()));
             } else if (type === 'circle') {
                 // Use average of width and height as new size, then calculate
                 // radius as a number from that:

--- a/test/tests/Shape.js
+++ b/test/tests/Shape.js
@@ -53,3 +53,26 @@ test('shape.toPath().toShape()', function() {
         equals(shape.toPath().toShape(), shape, name + '.toPath().toShape()');
     });
 });
+
+test('Shape.Rectangle radius works with negative size', function() {
+    var shape = new Shape.Rectangle({
+        center: [50, 50],
+        size: 50,
+        fillColor: 'black'
+    });
+
+    shape.size = [-25, -25];
+
+    equals(shape.radius.width, 0);
+    equals(shape.radius.height, 0);
+
+    shape.radius = [10, 50];
+    shape.size = [50, -25];
+
+    equals(shape.radius.width, 10);
+    equals(shape.radius.height, 12.5);
+
+    shape.size = [50, 75];
+
+    equals(shape.radius.height, 12.5);
+});


### PR DESCRIPTION
### Description

This PR fixes the handling of negative Shape.Rectangle sizes by taking the absolute value of the shape's `size` to calculate the shape's new `radius` in `Shape.setSize`.

#### Related issues

Resolves #1245

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
