### PR TITLE
Fix error when testing canvas

### DIFF
--- a/src/core/PaperScript.js
+++ b/src/core/PaperScript.js
@@ -16,7 +16,7 @@
  */
 Base.exports.PaperScript = function() {
     // `this` == global scope, as the function is called with `.call(this);`
-    var global = this,
+    var global = this || {},
         // See if there is a global Acorn in the browser already.
         acorn = global.acorn;
     // Also try importing an outside version of Acorn.


### PR DESCRIPTION
### Description

Error occurred when I use paper in mocha testing file. The error msg is `Cannot read property 'acorn' of undefined`. And the reason I found is that `this`, in file `src/core/PaperScript.js - Line 19`, is `undefined`. But it is just an empty Object when I use it in browser. So, I think it will always be safe if we have to use an attribute of an unknown Object.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <https://github.com/paperjs/paper.js/issues/1480>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the JSHint rules (`npm run jshint` passes)
