### PR TITLE
Fix: closed Path with blend mode throw error

### DIFF
--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2793,15 +2793,18 @@ statics: {
         }
 
         var length = segments.length - (closed ? 0 : 1);
-        for (var i = 1; i < length; i++)
-            addJoin(segments[i], join);
-        if (closed) {
-            // Go back to the beginning
-            addJoin(segments[0], join);
-        } else if (length > 0) {
-            // Handle caps on open paths
-            addCap(segments[0], cap);
-            addCap(segments[segments.length - 1], cap);
+        if (length > 0) {
+            for (var i = 1; i < length; i++) {
+                addJoin(segments[i], join);
+            }
+            if (closed) {
+                // Go back to the beginning
+                addJoin(segments[0], join);
+            } else {
+                // Handle caps on open paths
+                addCap(segments[0], cap);
+                addCap(segments[segments.length - 1], cap);
+            }
         }
         return bounds;
     },

--- a/test/tests/Path.js
+++ b/test/tests/Path.js
@@ -625,7 +625,7 @@ test('Path#getOffsetsWithTangent()', function() {
     equals(path.getOffsetsWithTangent([1, 0]), [0.25 * length, 0.75 * length], 'should not return duplicates when tangent is at segment point');
     equals(path.getOffsetsWithTangent([1, 1]).length, 2, 'should return 2 values when called on a circle with a diagonal vector');
 });
-  
+
 test('Path#add() with a lot of segments (#1493)', function() {
     var segments = [];
     for (var i = 0; i < 100000; i++) {
@@ -651,5 +651,15 @@ test('Path#arcTo(to, radius, rotation, clockwise, large) when from and to are eq
     var path = new Path();
     path.moveTo(point);
     path.arcTo(point, new Size(10), 0, true, true);
+    expect(0);
+});
+
+test('Path#closed with blend mode', function() {
+    new Path({
+        strokeColor: 'black',
+        blendMode: 'negation',
+        closed: true
+    });
+    view.update();
     expect(0);
 });


### PR DESCRIPTION
### Description
In some specific case, closed path was assumed to have at least one segment whereas this not always the case.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1755

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
