### PR TITLE
Fix: SVG import error stops script execution

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -607,8 +607,17 @@ new function() {
             insertItems = settings.insertItems;
         settings.applyMatrix = false;
         settings.insertItems = false;
-        var importer = importers[type],
-            item = importer && importer(node, type, options, isRoot) || null;
+        var importer = importers[type];
+        var item = null;
+        if (importer) {
+            // Catch import errors to allow final clean-up.
+            try {
+                item = importer(node, type, options, isRoot);
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
         settings.insertItems = insertItems;
         settings.applyMatrix = applyMatrix;
         if (item) {


### PR DESCRIPTION
### Description
This wraps the `importer(...)` call in a `try catch` block to catch eventual import error and still allow DOM cleaning after import.  
Note that the error is still logged in the console so that the user can correct it.
This is the minimal solution that I could think of but maybe this would be better to include more of the code in the `try` block to prevent the same problem with other parts of the code ?  
Also, I didn't write the related test because I am not so sure about how we should/could test this kind of problem. @lehni, some idea ?

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1754

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
