### PR TITLE
Fix Raster constructor

### DIFF
--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -112,28 +112,26 @@ var Raster = Item.extend(/** @lends Raster# */{
         // - An image (Image|Canvas|String) and an optional position (Point).
         // - A size (Size) describing the canvas that will be  created and an
         //   optional position (Point).
-        // If _initialize can set properties through object literal, we're done.
-        // Otherwise we need to check the type of object:       var image,
-        if (!this._initialize(source,
-                position !== undefined && Point.read(arguments))) {
-            var image,
-                type = typeof source,
-                object = type === 'string'
-                    ? document.getElementById(source)
-                    : type  === 'object'
-                        ? source
-                        : null;
-            if (object && object !== Item.NO_INSERT) {
-                if (object.getContext || object.naturalHeight != null) {
-                    image = object;
-                } else if (object) {
-                    // See if the arguments describe the raster size:
-                    var size = Size.read(arguments);
-                    if (!size.isZero()) {
-                        image = CanvasProvider.getCanvas(size);
-                    }
+        var image,
+            type = typeof source,
+            object = type === 'string'
+                ? document.getElementById(source)
+                : type === 'object'
+                    ? source
+                    : null;
+        if (object && object !== Item.NO_INSERT) {
+            if (object.getContext || object.naturalHeight != null) {
+                image = object;
+            } else if (object) {
+                // See if the arguments describe the raster size:
+                var size = Size.read(arguments);
+                if (!size.isZero()) {
+                    image = CanvasProvider.getCanvas(size);
                 }
             }
+        }
+        if (!this._initialize(source,
+            position !== undefined && Point.read(arguments, 1))) {
             if (image) {
                 // #setImage() handles both canvas and image types.
                 this.setImage(image);

--- a/test/tests/Raster.js
+++ b/test/tests/Raster.js
@@ -222,15 +222,24 @@ test('new Raster(size[, position])', function() {
     equals(raster.bounds, new Rectangle(-50, -50, 100, 100));
 
     // Size and position.
-    var raster = new Raster(new Size(100, 100), new Point(100, 100));
-    equals(raster.position, new Point(100, 100));
-    equals(raster.bounds, new Rectangle(50, 50, 100, 100));
+    var raster = new Raster(new Size(100, 100), new Point(200, 200));
+    equals(raster.position, new Point(200, 200));
+    equals(raster.bounds, new Rectangle(150, 150, 100, 100));
 
-    var raster = new Raster({size:new Size(100, 100), position:new Point(100, 100)});
-    equals(raster.position, new Point(100, 100));
-    equals(raster.bounds, new Rectangle(50, 50, 100, 100));
+    var raster = new Raster({size:new Size(100, 100), position:new Point(200, 200)});
+    equals(raster.position, new Point(200, 200));
+    equals(raster.bounds, new Rectangle(150, 150, 100, 100));
 
-    var raster = new Raster({width:100, height:100, position:new Point(100, 100)});
-    equals(raster.position, new Point(100, 100));
-    equals(raster.bounds, new Rectangle(50, 50, 100, 100));
+    var raster = new Raster({width:100, height:100, position:new Point(200, 200)});
+    equals(raster.position, new Point(200, 200));
+    equals(raster.bounds, new Rectangle(150, 150, 100, 100));
+});
+
+test('new Raster(source, position)', function() {
+    var position = new Point(0, 0);
+    var raster = new Raster(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAABlJREFUeNpi+s/AwPCfgYmR4f9/hv8AAQYAHiAFAS8Lwy8AAAAASUVORK5CYII=',
+        position
+    );
+    equals(raster.position, position);
 });


### PR DESCRIPTION



### Description
Corrects `new Raster(size, position)` tests that lead to false positives and adds new tests for `new Raster(source, position)`.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1768

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
