### PR TITLE
Allow hitTest() to look for 'container' classes

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -2092,6 +2092,13 @@ new function() { // Injection scope for hit-test functions shared with project
         }
 
         if (!res) {
+            
+            // if target class found, clear class option so subsequent 
+            // _hitTestXXX() calls will return valid results
+            const foundClass = options.class && this instanceof options.class;
+            if (foundClass) options = options.extend(
+                                { class: this instanceof CompoundPath ? Path : false });
+
             res = this._hitTestChildren(point, options, viewMatrix)
                 // NOTE: We don't call match on _hitTestChildren() because
                 // it is already called internally.
@@ -2102,6 +2109,9 @@ new function() { // Injection scope for hit-test functions shared with project
                         this.getStrokeScaling() ? null
                             : viewMatrix._shiftless().invert()))
                 || null;
+            
+            // if this is the target class item, replace res.item with it
+            if (foundClass && res) res.item = this;
         }
         // Transform the point back to the outer coordinate system.
         if (res && res.point) {

--- a/test/tests/HitResult.js
+++ b/test/tests/HitResult.js
@@ -591,43 +591,51 @@ test('hit-testing fills with tolerance', function() {
 });
 
 test('hit-testing compound-paths', function() {
-    var center = new Point(100, 100);
-    var path1 = new Path.Circle({
-        center: center,
-        radius: 100
-    });
-    var path2 = new Path.Circle({
-        center: center,
-        radius: 50
-    });
-    var compoundPath = new CompoundPath({
-        children: [path1, path2],
-        fillColor: 'blue',
-        fillRule: 'evenodd'
-    });
-    // When hit-testing a side, we should get a result on the torus
+  var center = new Point(100, 100);
+  var path1 = new Path.Circle({
+    center: center,
+    radius: 100
+  });
+  var path2 = new Path.Circle({
+    center: center,
+    radius: 50
+  });
+  var compoundPath = new CompoundPath({
+    children: [path1, path2],
+    fillColor: 'blue',
+    fillRule: 'evenodd'
+  });
+  // When hit-testing a side, we should get a result on the torus
     equals(function() {
-        var result = paper.project.hitTest(center.add([75, 0]), {
-            fill: true
-        });
-        return result && result.item === compoundPath;
-    }, true);
-    // When hit-testing the center, we should not get a result on the torus
+    var result = paper.project.hitTest(center.add([75, 0]), {
+      fill: true
+    });
+    return result && result.item === compoundPath;
+  }, true);
+  // When hit-testing the center, we should not get a result on the torus
     equals(function() {
-        var result = paper.project.hitTest(center, {
-            fill: true
-        });
-        return result === null;
-    }, true);
-    // When asking specifically for paths, she should get the top-most path in
-    // the center (the one that cuts out the hole)
+    var result = paper.project.hitTest(center, {
+      fill: true
+    });
+    return result === null;
+  }, true);
+  // When asking specifically for paths, she should get the top-most path in
+  // the center (the one that cuts out the hole)
     equals(function() {
-        var result = paper.project.hitTest(center, {
-            class: Path,
-            fill: true
-        });
-        return result && result.item === path2;
-    }, true);
+    var result = paper.project.hitTest(center, {
+      class: Path,
+      fill: true
+    });
+    return result && result.item === path2;
+  }, true);
+  // When asking specifically for CompoundPath, she should get the top-most compoundPath
+  equals(function() {
+    var result = paper.project.hitTest(center, {
+      class: CompoundPath,
+      fill: true
+    });
+    return result && result.item === compoundPath;
+  }, true);
 });
 
 test('hit-testing clipped items', function() {


### PR DESCRIPTION
### Description

This PR enables `hitTest()` option argument to specify a "container" class (e.g., `CompoundPath`, `Group`, `SymbolItem`) as its `class` key.

My use case is to be able to test if the mouse pointer is over a particular `SymbolItem` (actually, a derived class thereof). Originally, `hitTest()` returns null with `options = { class: SymbolItem, ... }`

#### Related issues

None I could find.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
