### PR TITLE
Fix typescript returned instance type

### DIFF
--- a/gulp/typescript/typescript-definition-generator.js
+++ b/gulp/typescript/typescript-definition-generator.js
@@ -329,10 +329,10 @@ function formatJSDoc(offset, render) {
 function getMethodReturnType(method) {
     // We need to handle the special case where the method returns an instance
     // of the class. As JSDoc doesn't have a proper way to handle this, we rely
-    // on the custom tag `@tsReturnThis`, placed in the description of the
+    // on the custom tag `@chainable`, placed in the description of the
     // method. When this tag is present, we ignore the common return type and
     // use typescript `this` type instead.
-    if (method.comment.tags.find(it => it.title === 'tsReturnThis')) {
+    if (method.comment.tags.find(it => it.title === 'chainable')) {
         return 'this';
     }
     return method.returnType || method.returns.length > 0 && method.returns[0].type;

--- a/gulp/typescript/typescript-definition-generator.js
+++ b/gulp/typescript/typescript-definition-generator.js
@@ -327,6 +327,15 @@ function formatJSDoc(offset, render) {
 }
 
 function getMethodReturnType(method) {
+    // We need to handle the special case where the method returns an instance
+    // of the class. As JSDoc doesn't have a proper way to handle this, we rely
+    // on the custom tag `@tsReturnThis`, placed in the description of the
+    // method. When this tag is present, we ignore the common return type and
+    // use typescript `this` type instead.
+    if (method.comment.tags.find(it => it.title === 'tsReturnThis'))
+    {
+        return 'this';
+    }
     return method.returnType || method.returns.length > 0 && method.returns[0].type;
 }
 

--- a/gulp/typescript/typescript-definition-generator.js
+++ b/gulp/typescript/typescript-definition-generator.js
@@ -332,8 +332,7 @@ function getMethodReturnType(method) {
     // on the custom tag `@tsReturnThis`, placed in the description of the
     // method. When this tag is present, we ignore the common return type and
     // use typescript `this` type instead.
-    if (method.comment.tags.find(it => it.title === 'tsReturnThis'))
-    {
+    if (method.comment.tags.find(it => it.title === 'tsReturnThis')) {
         return 'this';
     }
     return method.returnType || method.returns.length > 0 && method.returns[0].type;

--- a/gulp/typescript/typescript-definition-test.ts
+++ b/gulp/typescript/typescript-definition-test.ts
@@ -683,6 +683,14 @@ path.getWeightedTangentAt(0);
 path.getWeightedNormalAt(0);
 path.getCurvatureAt(0);
 path.getOffsetsWithTangent(point);
+path = path.set(object);
+path = path.clone();
+path = path.addTo(group);
+path = path.copyTo(group);
+path = path.on('', callback);
+path = path.on({});
+path = path.off('', callback);
+path = path.off({});
 
 
 //

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -250,6 +250,7 @@ new function() { // Injection scope for various item event handlers
      * @function
      * @param {Object} props
      * @return {Item} the item itself
+     * @tsReturnThis
      *
      * @example {@paperscript}
      * // Setting properties through an object literal
@@ -1611,6 +1612,7 @@ new function() { // Injection scope for various item event handlers
      * @param {Object} [options={ insert: true, deep: true }]
      *
      * @return {Item} the newly cloned item
+     * @tsReturnThis
      *
      * @example {@paperscript}
      * // Cloning items:
@@ -2663,6 +2665,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @param {Project|Layer|Group|CompoundPath} owner the item or project to
      * add the item to
      * @return {Item} the item itself, if it was successfully added
+     * @tsReturnThis
      */
     addTo: function(owner) {
         return owner._insertItem(undefined, this);
@@ -2675,6 +2678,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @param {Project|Layer|Group|CompoundPath} owner the item or project to
      * copy the item to
      * @return {Item} the new copy of the item, if it was successfully added
+     * @tsReturnThis
      */
     copyTo: function(owner) {
         return this.clone(false).addTo(owner);
@@ -4139,6 +4143,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     occurs, receiving a {@link MouseEvent} or {@link Event} object as its
      *     sole argument
      * @return {Item} this item itself, so calls can be chained
+     * @tsReturnThis
      *
      * @example {@paperscript}
      * // Change the fill color of the path to red when the mouse enters its
@@ -4170,6 +4175,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     properties: {@values frame, mousedown, mouseup, mousedrag, click,
      *     doubleclick, mousemove, mouseenter, mouseleave}
      * @return {Item} this item itself, so calls can be chained
+     * @tsReturnThis
      *
      * @example {@paperscript}
      * // Change the fill color of the path to red when the mouse enters its
@@ -4229,6 +4235,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     'mouseenter', 'mouseleave'}
      * @param {Function} function the function to be detached
      * @return {Item} this item itself, so calls can be chained
+     * @tsReturnThis
      */
     /**
      * Detach one or more event handlers to the item.
@@ -4239,6 +4246,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     properties: {@values frame, mousedown, mouseup, mousedrag, click,
      *     doubleclick, mousemove, mouseenter, mouseleave}
      * @return {Item} this item itself, so calls can be chained
+     * @tsReturnThis
      */
 
     /**

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -250,7 +250,7 @@ new function() { // Injection scope for various item event handlers
      * @function
      * @param {Object} props
      * @return {Item} the item itself
-     * @tsReturnThis
+     * @chainable
      *
      * @example {@paperscript}
      * // Setting properties through an object literal
@@ -1612,7 +1612,7 @@ new function() { // Injection scope for various item event handlers
      * @param {Object} [options={ insert: true, deep: true }]
      *
      * @return {Item} the newly cloned item
-     * @tsReturnThis
+     * @chainable
      *
      * @example {@paperscript}
      * // Cloning items:
@@ -2665,7 +2665,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @param {Project|Layer|Group|CompoundPath} owner the item or project to
      * add the item to
      * @return {Item} the item itself, if it was successfully added
-     * @tsReturnThis
+     * @chainable
      */
     addTo: function(owner) {
         return owner._insertItem(undefined, this);
@@ -2678,7 +2678,7 @@ new function() { // Injection scope for hit-test functions shared with project
      * @param {Project|Layer|Group|CompoundPath} owner the item or project to
      * copy the item to
      * @return {Item} the new copy of the item, if it was successfully added
-     * @tsReturnThis
+     * @chainable
      */
     copyTo: function(owner) {
         return this.clone(false).addTo(owner);
@@ -4143,7 +4143,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     occurs, receiving a {@link MouseEvent} or {@link Event} object as its
      *     sole argument
      * @return {Item} this item itself, so calls can be chained
-     * @tsReturnThis
+     * @chainable
      *
      * @example {@paperscript}
      * // Change the fill color of the path to red when the mouse enters its
@@ -4175,7 +4175,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     properties: {@values frame, mousedown, mouseup, mousedrag, click,
      *     doubleclick, mousemove, mouseenter, mouseleave}
      * @return {Item} this item itself, so calls can be chained
-     * @tsReturnThis
+     * @chainable
      *
      * @example {@paperscript}
      * // Change the fill color of the path to red when the mouse enters its
@@ -4235,7 +4235,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     'mouseenter', 'mouseleave'}
      * @param {Function} function the function to be detached
      * @return {Item} this item itself, so calls can be chained
-     * @tsReturnThis
+     * @chainable
      */
     /**
      * Detach one or more event handlers to the item.
@@ -4246,7 +4246,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *     properties: {@values frame, mousedown, mouseup, mousedrag, click,
      *     doubleclick, mousemove, mouseenter, mouseleave}
      * @return {Item} this item itself, so calls can be chained
-     * @tsReturnThis
+     * @chainable
      */
 
     /**


### PR DESCRIPTION
### Description

See the related issue for a reproduction case.  
The problem is that JSDoc itself doesn't have a way to solve this issue, as shown here: https://github.com/jsdoc/jsdoc/issues/991  
So the best workaround (also used by other libraries) seems to be using a custom JSDoc tag that is only understood by the TypeScript definition generator. When this tag is detected, the return type is replaced by TypeScript `this` type which perfectly solves this issue (it is actually done for this specific use case).

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Closes #1795

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
