### PR TITLE
docs: Fix simple typo, horziontal -> horizontal

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -3465,7 +3465,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#shear
      * @function
-     * @param {Point} shear the horziontal and vertical shear factors as a point
+     * @param {Point} shear the horizontal and vertical shear factors as a point
      * @param {Point} [center={@link Item#position}]
      * @see Matrix#shear(shear[, center])
      */
@@ -3487,7 +3487,7 @@ new function() { // Injection scope for hit-test functions shared with project
      *
      * @name Item#skew
      * @function
-     * @param {Point} skew the horziontal and vertical skew angles in degrees
+     * @param {Point} skew the horizontal and vertical skew angles in degrees
      * @param {Point} [center={@link Item#position}]
      * @see Matrix#shear(skew[, center])
      */

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -633,7 +633,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#shear
      * @function
-     * @param {Point} shear the horziontal and vertical shear factors as a point
+     * @param {Point} shear the horizontal and vertical shear factors as a point
      * @param {Point} [center={@link View#center}]
      * @see Matrix#shear(shear[, center])
      */
@@ -655,7 +655,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
      *
      * @name View#skew
      * @function
-     * @param {Point} skew the horziontal and vertical skew angles in degrees
+     * @param {Point} skew the horizontal and vertical skew angles in degrees
      * @param {Point} [center={@link View#center}]
      * @see Matrix#shear(skew[, center])
      */


### PR DESCRIPTION
There is a small typo in src/item/Item.js, src/view/View.js.

Should read `horizontal` rather than `horziontal`.

