### PR TITLE
Fix detection of Option + Space key on macOS

### DIFF
--- a/src/event/Key.js
+++ b/src/event/Key.js
@@ -19,6 +19,7 @@ var Key = new function() {
             // Unify different key identifier naming schemes, e.g. on Gecko, IE:
             '\t': 'tab',
             ' ': 'space',
+            '\xA0': 'space', // Option + Space on macOS = non-breaking space.
             '\b': 'backspace',
             '\x7f': 'delete',
             'Spacebar': 'space',


### PR DESCRIPTION
The Option + Space key combination on macOS results in a non-breaking
space (U+00A0). This resulted in the modifiers not correctly detecting
the release of the space key.

To reproduce on a mac:
* Log `event.modifiers.space`: http://sketch.paperjs.org/#V/0.12.4/S/JcwxDoJAEEbhq0ymksTsATAegcpSLNZh0A3L/IRZaAh3B2P5vuJtbHFUrvkxaJEvX1nQ/boAOcAaLK4NVqU79YtJSbCLrmqloq01IoE5soaMz9/DiC71SWcPPkXR6tbafn7fs8ZhQrLiXD9f+wE=
* Click into canvas to give it focus (otherwise space may enter a space somewhere else)
* Continuously move mouse around to generate console outputs.
* Hold down space key.
* While still holding space, hold down option key.
* While still holding option key, release space key.

Expected:
* Console log switches back to `false`.

Actual:
* Console log continues to log `true` as the modifier is "stuck".