### PR TITLE
Add JSDoc comments for additional PaperScope methods

### DIFF
--- a/src/core/PaperScope.js
+++ b/src/core/PaperScope.js
@@ -265,6 +265,19 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
         return this;
     },
 
+    /**
+     * Returns a valid HTML canvas you can use. Internally, this may reuse an existing canvas.
+     *
+     * This either accepts width and height as two arguments, or you can pass in an object with "width" and "height" properties.
+     *
+     * @param {Number|Object} width
+     * @param {Number} height
+     *
+     * @option width {Number}
+     * @option height {Number}
+     *
+     * @returns {HTMLCanvasElement}
+    */
     createCanvas: function(width, height) {
         return CanvasProvider.getCanvas(width, height);
     },
@@ -277,9 +290,11 @@ var PaperScope = Base.extend(/** @lends PaperScope# */{
         paper = this;
     },
 
+    /**
+     * Remove all projects, views and tools.
+     * This also removes the installed event handlers.
+     */
     clear: function() {
-        // Remove all projects, views and tools.
-        // This also removes the installed event handlers.
         var projects = this.projects,
             tools = this.tools;
         for (var i = projects.length - 1; i >= 0; i--)


### PR DESCRIPTION
### Description

The TypeScript type definitions don't include `createCanvas` or `clear` on the PaperScope object. This PR adds JSDoc comments for those two functions so they show up in both the online documentation and the generated `.d.ts` typings files.

This is a comment/documentation-only change.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
