### PR TITLE
 Fix stroke bounds for paths

### DIFF
--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -858,8 +858,8 @@ statics: /** @lends Curve */{
         }
 
         padding /= 2; // strokePadding is in width, not radius
-        var minPad = min[coord] - padding,
-            maxPad = max[coord] + padding;
+        var minPad = min[coord] + padding,
+            maxPad = max[coord] - padding;
         // Perform a rough bounds checking first: The curve can only extend the
         // current bounds if at least one value is outside the min-max range.
         if (    v0 < minPad || v1 < minPad || v2 < minPad || v3 < minPad ||

--- a/test/tests/Item_Bounds.js
+++ b/test/tests/Item_Bounds.js
@@ -808,3 +808,19 @@ test('path.strokeBounds of open, circular arc (#1817)', function() {
     equals(circle.strokeBounds, new Rectangle(4, 4, 24, 12),
             'circle.strokeBounds');
 });
+
+test('path.strokeBounds applies stroke padding properly (#1824)', function() {
+    var ellipse = new Path.Ellipse({
+        point: [100, 100],
+        size: [50, 80],
+        strokeWidth: 32,
+        strokeColor: 'red'
+    });
+
+    ellipse.rotate(50);
+    equals(
+        ellipse.strokeBounds,
+        new Rectangle(74.39306, 91.93799, 101.21388, 96.12403),
+        'ellipse.strokeBounds'
+    );
+})


### PR DESCRIPTION
### Description
The padding-plus-minmax check in https://github.com/paperjs/paper.js/pull/1082 was being done backwards-- we should have been checking if values were less than the current minimum with padding subtracted from the *values*, and greater than the current maximum with padding added, but we were subtracting padding from the *minimum* (and adding padding to the maximum).

Instead, we now add padding to the minimum and subtract it from the maximum, which is equivalent to subtracting padding from the values when comparing them to the minimum and adding padding to the values when comparing them to the maximum.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to #1824

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
