### PR TITLE
Fix install in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "load": "gulp load",
     "jshint": "gulp jshint",
     "test": "gulp test",
-    "preinstall": "[ $npm_config_heading = 'npm' ] && npx npm-force-resolutions || true"
+    "postshrinkwrap": "npx --quiet npm-force-resolutions && npm install --no-package-lock --no-audit --no-fund --no-progress --silent"
   },
   "files": [
     "AUTHORS.md",


### PR DESCRIPTION
### Description
This PR would fix installation error in Windows.
I have tested `npm install` and `yarn install` in paper.js directory with Windows 10, nodejs v12.6.3, npm 6.14.4 and yarn 1.22.4.

#### Related issues

Fixes #1833