### PR TITLE
Add null check for 2d context in CanvasView

### DIFF
--- a/src/view/CanvasView.js
+++ b/src/view/CanvasView.js
@@ -43,6 +43,10 @@ var CanvasView = View.extend(/** @lends CanvasView# */{
             canvas = CanvasProvider.getCanvas(size);
         }
         var ctx = this._context = canvas.getContext('2d');
+        if (!ctx) {
+            throw new Error('Canvas ' + canvas +
+                ' is unable to provide a 2D context.');
+        }
         // Save context right away, and restore in #remove(). Also restore() and
         // save() again in _setElementSize() to prevent accumulation of scaling.
         ctx.save();


### PR DESCRIPTION
### Description

Sometimes we are getting errors logged and reported with the vague error message "null is not an object (evaluating r.save)".

I traced it to this line.

It seems there was already a similar check & error in CanvasProvider so I copied that error here.

Although this does not prevent the problem, it at least will give us a clearer error when the problem occurs.

As for why a 2D context cannot be created, we are still looking into it.  Maybe the device (iPad) is running out of graphics memory?