### PR TITLE
Adds support for empty arguments to getIntersections' typings

### DIFF
--- a/gulp/typescript/typescript-definition-test.ts
+++ b/gulp/typescript/typescript-definition-test.ts
@@ -579,6 +579,7 @@ pathItem.divide(path, {});
 pathItem.reorient();
 pathItem.reorient(true);
 pathItem.reorient(true, true);
+pathItem.getIntersections();
 pathItem.getIntersections(path);
 pathItem.getIntersections(path, callback);
 pathItem.getCrossings(path);

--- a/src/path/PathItem.js
+++ b/src/path/PathItem.js
@@ -288,7 +288,7 @@ var PathItem = Item.extend(/** @lends PathItem# */{
      * of {@link CurveLocation} objects. {@link CompoundPath} items are also
      * supported.
      *
-     * @param {PathItem} path the other item to find the intersections with
+     * @param {PathItem} [path] the other item to find the intersections with
      * @param {Function} [include] a callback function that can be used to
      *     filter out undesired locations right while they are collected. When
      *     defined, it shall return {@true to include a location}.


### PR DESCRIPTION
### Description
This fixes PathItem `getIntersections` typings to enable support for an empty argument.

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
