### PR TITLE
Fix Line#getSignedDistance and add tests to avoid regression

### DIFF
--- a/src/basic/Line.js
+++ b/src/basic/Line.js
@@ -199,9 +199,9 @@ var Line = Base.extend(/** @lends Line# */{
               return  vx === 0 ? (vy > 0 ? x - px : px - x)
                     : vy === 0 ? (vx < 0 ? y - py : py - y)
                     : ((x - px) * vy - (y - py) * vx) / (
-                        vy > vx
-                            ? vy * Math.sqrt(1 + (vx * vx) / (vy * vy))
-                            : vx * Math.sqrt(1 + (vy * vy) / (vx * vx))
+                        Math.abs(vy) > Math.abs(vx)
+                            ? Math.abs(vy) * Math.sqrt(1 + (vx * vx) / (vy * vy))
+                            : Math.abs(vx) * Math.sqrt(1 + (vy * vy) / (vx * vx))
                     );
         },
 

--- a/test/tests/Line.js
+++ b/test/tests/Line.js
@@ -1,0 +1,64 @@
+/*
+ * Paper.js - The Swiss Army Knife of Vector Graphics Scripting.
+ * http://paperjs.org/
+ *
+ * Copyright (c) 2011 - 2020, Jürg Lehni & Jonathan Puckey
+ * http://juerglehni.com/ & https://puckey.studio/
+ *
+ * Distributed under the MIT license. See LICENSE file for details.
+ *
+ * All rights reserved.
+ */
+
+QUnit.module('Line');
+
+test('new Line(10, 20, 30, 40)', function() {
+    var line = new Line(10, 20, 30, 40);
+    equals(line._px, 10, 'point._px');
+    equals(line._py, 20, 'point._py');
+    // _vx = p2.x - p1.x
+    equals(line._vx, 20, 'point._vx');
+    // _vy = p2.y - p1.y
+    equals(line._vy, 20, 'point._vy');
+});
+
+test('new Line(10, 20, 30, 40, true)', function() {
+    var line = new Line(10, 20, 30, 40, true);
+    equals(line._px, 10, 'point._px');
+    equals(line._py, 20, 'point._py');
+    equals(line._vx, 30, 'point._vx');
+    equals(line._vy, 40, 'point._vy');
+});
+
+test('getDistance()', function() {
+    equals(function() {
+        return new Line(10, 20, 20, 10, true).getDistance(new Point(20, 10));
+    }, 13.416407864998737);
+    equals(function() {
+        return new Line(10, 20, -20, -10, true).getDistance(new Point(20, 10));
+    }, 13.416407864998737);
+    equals(function() {
+        return new Line(10, 20, 20, 10, true).getDistance(new Point(0, 30));
+    }, 13.416407864998737);
+    equals(function() {
+        return new Line(10, 20, -20, -10, true).getDistance(new Point(0, 30));
+    }, 13.416407864998737);
+});
+
+test('getSignedDistance()', function() {
+    equals(function() {
+        return new Line(10, 20, 20, 10, true).getSignedDistance(new Point(20, 10));
+    }, 13.416407864998737);
+    equals(function() {
+        // Change the line direction
+        return new Line(10, 20, -20, -10, true).getSignedDistance(new Point(20, 10));
+    }, -13.416407864998737);
+    equals(function() {
+        // Change the point side
+        return new Line(10, 20, 20, 10, true).getSignedDistance(new Point(0, 30));
+    }, -13.416407864998737);
+    equals(function() {
+        // Change the line direction and the point side
+        return new Line(10, 20, -20, -10, true).getSignedDistance(new Point(0, 30));
+    }, 13.416407864998737);
+});

--- a/test/tests/load.js
+++ b/test/tests/load.js
@@ -11,6 +11,7 @@
  */
 
 /*#*/ include('Point.js');
+/*#*/ include('Line.js');
 /*#*/ include('Size.js');
 /*#*/ include('Rectangle.js');
 /*#*/ include('Matrix.js');


### PR DESCRIPTION
### Description
The proposed calculation for `getSignedDistance` is wrong.

When rewriting:

Math.sqrt(vx*vx+vy*vy)

into:

vy * Math.sqrt(1 + (vx * vx) / (vy * vy))

The sign of vy may break the equivalence, it should be:

Math.abs(vy) * Math.sqrt(1 + (vx * vx) / (vy * vy))

#### Related issues
- Relates to #1262 

### Checklist
- [X] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the JSHint rules (`npm run jshint` passes)
