### PR TITLE
Add setter for item.index

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1587,6 +1587,15 @@ new function() { // Injection scope for various item event handlers
         return this._index;
     },
 
+    setIndex: function(index) {
+        var parent = this._parent,
+            children = parent && parent._children;
+        if (children) {
+            parent.insertChildren(index in children ? index : undefined,
+                                  [this]);
+        }
+    },
+
     equals: function(item) {
         // NOTE: We do not compare name and selected state.
         // TODO: Consider not comparing locked and visible also?

--- a/test/tests/Item_Order.js
+++ b/test/tests/Item_Order.js
@@ -113,3 +113,16 @@ test('Item#insertChild() with already inserted children', function() {
     item4.parent.insertChild(oldIndex, item4);
     equals(function() { return item4.index; }, oldIndex);
 });
+
+test('Item#index getter setter', function() {
+    var item1 = new Group(),
+        item2 = new Group(),
+        item3 = new Group(),
+        item4 = new Group(),
+        newIndex = 2;
+    item4.index = newIndex;
+    equals(function() { return item4.index; }, newIndex);
+    newIndex = 0;
+    item4.index = newIndex;
+    equals(function() { return item4.index; }, newIndex);
+});


### PR DESCRIPTION
### Description
Add setter for item.index which is proposed in #1908 .

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to #1908 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
