### PR TITLE
Add missing docs for Point.negate() function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@
 - Scott Kieronski <baroes0239@gmail.com>
 - Samuel Asensi <asensi.samuel@gmail.com>
 - Takahiro Nishino <sapics.dev@gmail.com>
+- Piotr Wilczynski <delwing@gmail.com>

--- a/src/basic/Point.js
+++ b/src/basic/Point.js
@@ -688,6 +688,18 @@ var Point = Base.extend(/** @lends Point# */{
         return new Point(this.x % point.x, this.y % point.y);
     },
 
+    /**
+     * Returns new point with both coordinates negated.
+     * @name Point#negate
+     * @function
+     * @operator
+     * @returns {Point} negation of both coordinates as new point.
+     * 
+     * @example
+     * var point = new Point(12, -6);
+     * console.log(-point); // {x: -12, y: 6}
+     * console.log(point.negate()); // {x: -12, y: 6}
+     */
     negate: function() {
         return new Point(-this.x, -this.y);
     },


### PR DESCRIPTION
### Description

I've noticed that `.negate()` function though existing in Point class itself it's not in .ts docs.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
