### PR TITLE
Fix contributing upstream URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ fork](https://help.github.com/articles/fork-a-repo/). Then do this:
 
     git clone --recursive git@github.com:yourusername/paper.js.git
     cd paper.js
-    git remote add upstream git://github.com/paperjs/paper.js.git
+    git remote add upstream git@github.com:paperjs/paper.js.git
 
 To then fetch changes from upstream, run
 


### PR DESCRIPTION
### Description

Fix invalid contributing upstream url.

```sh
$ git remote add upstream git://github.com/paperjs/paper.js.git
$ git fetch upstream -v
Looking up github.com ... done.
Connecting to github.com (port 9418) ... fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out

```

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
