### PR TITLE
Fix createPath arguments not being passed down to Path constructor

### DIFF
--- a/src/path/Path.Constructors.js
+++ b/src/path/Path.Constructors.js
@@ -22,7 +22,10 @@ Path.inject({ statics: new function() {
 
     function createPath(segments, closed, args) {
         var props = Base.getNamed(args),
-            path = new Path(props && props.insert == false && Item.NO_INSERT);
+            path = new Path(props && (props.insert == true
+                ? { insert: true }
+                : props.insert == false && Item.NO_INSERT
+            ));
         path._add(segments);
         // No need to use setter for _closed since _add() called _changed().
         path._closed = closed;

--- a/test/tests/Path_Constructors.js
+++ b/test/tests/Path_Constructors.js
@@ -35,6 +35,13 @@ test('new Path.Circle({ center: [100, 100], radius: 50 })', function() {
     equals(path.segments.toString(), '{ point: { x: 50, y: 100 }, handleIn: { x: 0, y: 27.61424 }, handleOut: { x: 0, y: -27.61424 } },{ point: { x: 100, y: 50 }, handleIn: { x: -27.61424, y: 0 }, handleOut: { x: 27.61424, y: 0 } },{ point: { x: 150, y: 100 }, handleIn: { x: 0, y: -27.61424 }, handleOut: { x: 0, y: 27.61424 } },{ point: { x: 100, y: 150 }, handleIn: { x: 27.61424, y: 0 }, handleOut: { x: -27.61424, y: 0 } }');
 });
 
+test('new Path.Circle({ center: [100, 100], radius: 50, insert: true })', function() {
+    paper.settings.insertItems = false;
+    var path = new Path.Circle({ center: [100, 100], radius: 50, insert: true });
+    equals(path.isInserted(), true);
+    paper.settings.insertItems = true;
+});
+
 test('new Path.Ellipse(rect)', function() {
     var rect = new Rectangle([500, 500], [1000, 750]);
     var path = new Path.Ellipse(rect);


### PR DESCRIPTION
### Description
I believe I have found a bug in `paper.js`. I am using javascript directly, so no PaperScript. My use case is the following:

```js
// insertItems is turned off globally because I am using react-reconciler to handle rendering
paper.settings.insertItems = false;

// one of my tools has a use case, where I need to bypass react's rendering mechanism
var circle = new paper.Path.Circle({ insert: true });

// but circle is not inserted into the project and thus not visible until I render it with react
console.log(circle.isInserted()) // false
```
`Path.Circle` calls `createEllipse`, which calls `createPath`, which does not pass arguments to Path constructor.

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
