### PR TITLE
Issue #1993: Feature Request - Add SVG export option to link images and define them in the defs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@
 - Scott Kieronski <baroes0239@gmail.com>
 - Samuel Asensi <asensi.samuel@gmail.com>
 - Takahiro Nishino <sapics.dev@gmail.com>
+- Blayze Wilhelm <blayze@carstickers.com>

--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -106,11 +106,14 @@ new function() {
             || item.toDataURL();
 
         if (options.linkRaster) {
-            var raster = SvgElement.create('image', {
-                href: image_href
-            }, formatter);
+            var raster = getDefinition(item, 'image');
 
-            setDefinition(item, raster, 'image');
+            if (!raster) {
+                raster = SvgElement.create('image', {
+                    href: image_href
+                }, formatter);
+                setDefinition(item, raster, 'image');
+            }
 
             attrs.href = '#' + raster.id;
 
@@ -347,10 +350,25 @@ new function() {
     function getDefinition(item, type) {
         if (!definitions)
             definitions = { ids: {}, svgs: {} };
-        // Use #__id for items that don't have internal #_id properties (Color),
-        // and give them ids from their own private id pool named 'svg'.
-        return item && definitions.svgs[type + '-'
-                + (item._id || item.__id || (item.__id = UID.get('svg')))];
+
+        var svgDefinitionId;
+        if (type === 'image') {
+            // Image ids in the definitions are based on the source
+            // instead of the element id in order to link multiple
+            // raster elements to the same image using the use tag
+            var imageSource = item.getSource();
+            svgDefinitionId =  definitions.ids[type] &&
+                definitions.ids[type][imageSource] &&
+                (type + '-' + definitions.ids[type][imageSource]);
+        }
+        else {
+            // Use #__id for items that don't have internal #_id properties (Color),
+            // and give them ids from their own private id pool named 'svg'.
+            svgDefinitionId = item && type + '-' +
+                (item._id || item.__id || (item.__id = UID.get('svg')));
+        }
+
+        return item && definitions.svgs[svgDefinitionId];
     }
 
     function setDefinition(item, node, type) {
@@ -358,12 +376,34 @@ new function() {
         // This is required by 'clip', where getDefinition() is not called.
         if (!definitions)
             getDefinition();
+
         // Have different id ranges per type
-        var typeId = definitions.ids[type] = (definitions.ids[type] || 0) + 1;
+        var typeId;
+        var svgDefinitionId;
+        if (type === 'image') {
+            // Images in the definitions needs to be unique to the source
+            // instead of the element
+            if (!definitions.ids[type]) {
+                definitions.ids[type] = Object.create(null);
+            }
+            var imageSource = item.getSource();
+            typeId = definitions.ids[type][imageSource] =
+                definitions.ids[type][imageSource] ||
+                Object.keys(definitions.ids[type]).length + 1;
+
+            svgDefinitionId =  type + '-' + typeId;
+        }
+        else {
+            typeId = definitions.ids[type] = (definitions.ids[type] || 0) + 1;
+
+            // See getDefinition() for an explanation of #__id:
+            svgDefinitionId = type + '-' + (item._id || item.__id);
+        }
+
         // Give the svg node an id, and link to it from the item id.
         node.id = type + '-' + typeId;
-        // See getDefinition() for an explanation of #__id:
-        definitions.svgs[type + '-' + (item._id || item.__id)] = node;
+
+        definitions.svgs[svgDefinitionId] = node;
     }
 
     function exportDefinitions(node, options) {

--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -95,14 +95,30 @@ new function() {
         var attrs = getTransform(item._matrix, true),
             size = item.getSize(),
             image = item.getImage();
+
         // Take into account that rasters are centered:
         attrs.x -= size.width / 2;
         attrs.y -= size.height / 2;
         attrs.width = size.width;
         attrs.height = size.height;
-        attrs.href = options.embedImages == false && image && image.src
-                || item.toDataURL();
-        return SvgElement.create('image', attrs, formatter);
+
+        var image_href = options.embedImages == false && image && image.src
+            || item.toDataURL();
+
+        if (options.linkRaster) {
+            var raster = SvgElement.create('image', {
+                href: image_href
+            }, formatter);
+
+            setDefinition(item, raster, 'image');
+
+            attrs.href = '#' + raster.id;
+
+            return SvgElement.create('use', attrs, formatter);
+        } else {
+            attrs.href = image_href;
+            return SvgElement.create('image', attrs, formatter);
+        }
     }
 
     function exportPath(item, options) {

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -291,4 +291,66 @@ if (!isNodeContext) {
             compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
         };
     });
+    test('Export multiple rasters linked from a data url without duplicating data', function (assert) {
+        var dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAARUlEQVR42u3PQQ0AAAjEMM6/aMACT5IuM9B01f6/gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBcGuAsY8/q7uoYAAAAAElFTkSuQmCC';
+        var raster1 = new Raster(dataURL);
+        var raster2 = new Raster(dataURL);
+
+        var done = assert.async();
+
+        function validate() {
+            raster1.setBounds(0, 0, 50, 50);
+            raster2.setBounds(50, 50, 50, 50);
+
+            var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
+            assert.equal(defs.length, 1, 'The svg is missing the defs element');
+            assert.equal(defs[0].children.length, 1, 'The defs element should only have a single image');
+
+            compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
+        }
+
+        var raster1Loaded = new Promise(function (resolve, reject) {
+            raster1.onLoad = function() {
+                resolve();
+            };
+        });
+        var raster2Loaded = new Promise(function (resolve, reject) {
+            raster2.onLoad = function() {
+                resolve();
+            };
+        });
+
+        Promise.all([raster1Loaded, raster2Loaded]).then(validate);
+    });
+    test('Export multiple rasters linked from a url without duplicating data', function (assert) {
+        var standardURL = 'assets/paper-js.gif';
+        var raster1 = new Raster(standardURL);
+        var raster2 = new Raster(standardURL);
+
+        var done = assert.async();
+
+        function validate() {
+            raster1.setBounds(0, 0, 50, 50);
+            raster2.setBounds(50, 50, 50, 50);
+
+            var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
+            assert.equal(defs.length, 1, 'The svg is missing the defs element');
+            assert.equal(defs[0].children.length, 1, 'The defs element should only have a single image');
+
+            compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
+        }
+
+        var raster1Loaded = new Promise(function (resolve, reject) {
+            raster1.onLoad = function() {
+                resolve();
+            };
+        });
+        var raster2Loaded = new Promise(function (resolve, reject) {
+            raster2.onLoad = function() {
+                resolve();
+            };
+        });
+
+        Promise.all([raster1Loaded, raster2Loaded]).then(validate);
+    });
 }

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -244,4 +244,53 @@ if (!isNodeContext) {
         var svg = project.exportSVG({ bounds: 'content', asString: true });
         compareSVG(assert.async(), svg, project.activeLayer);
     });
+
+    test('Export raster inline from a data url', function (assert) {
+        var raster = new Raster('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAARUlEQVR42u3PQQ0AAAjEMM6/aMACT5IuM9B01f6/gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBcGuAsY8/q7uoYAAAAAElFTkSuQmCC');
+
+        var done = assert.async();
+        raster.onLoad = function() {
+            raster.setBounds(0, 0, 100, 100);
+            compareSVG(done, project.exportSVG({asString: true}), project.activeLayer);
+        };
+    });
+    test('Export raster inline from a url', function (assert) {
+        var raster = new Raster('assets/paper-js.gif');
+
+        var done = assert.async();
+        raster.onLoad = function() {
+            raster.setBounds(0, 0, 100, 100);
+            compareSVG(done, project.exportSVG({asString: true}), project.activeLayer);
+        };
+    });
+    test('Export raster linked from a data url', function (assert) {
+        var raster = new Raster('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAARUlEQVR42u3PQQ0AAAjEMM6/aMACT5IuM9B01f6/gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIBcGuAsY8/q7uoYAAAAAElFTkSuQmCC');
+
+        var done = assert.async();
+        raster.onLoad = function() {
+            raster.setBounds(0, 0, 100, 100);
+
+            var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
+            if (defs.length !== 1 || defs[0].children.length !== 1) {
+                console.error('Image was not added to the defs');
+            }
+
+            compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
+        };
+    });
+    test('Export raster linked from a url', function (assert) {
+        var raster = new Raster('assets/paper-js.gif');
+
+        var done = assert.async();
+        raster.onLoad = function() {
+            raster.setBounds(0, 0, 100, 100);
+
+            var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
+            if (defs.length !== 1 || defs[0].children.length !== 1) {
+                console.error('Image was not added to the defs');
+            }
+
+            compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
+        };
+    });
 }

--- a/test/tests/SvgExport.js
+++ b/test/tests/SvgExport.js
@@ -271,9 +271,8 @@ if (!isNodeContext) {
             raster.setBounds(0, 0, 100, 100);
 
             var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
-            if (defs.length !== 1 || defs[0].children.length !== 1) {
-                console.error('Image was not added to the defs');
-            }
+            assert.equal(defs.length, 1, 'The svg is missing the defs element');
+            assert.equal(defs[0].children.length, 1, 'The defs element is missing the image');
 
             compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
         };
@@ -286,9 +285,8 @@ if (!isNodeContext) {
             raster.setBounds(0, 0, 100, 100);
 
             var defs = project.exportSVG({linkRaster: true}).getElementsByTagName('defs');
-            if (defs.length !== 1 || defs[0].children.length !== 1) {
-                console.error('Image was not added to the defs');
-            }
+            assert.equal(defs.length, 1, 'The svg is missing the defs element');
+            assert.equal(defs[0].children.length, 1, 'The defs element is missing the image');
 
             compareSVG(done, project.exportSVG({linkRaster: true, asString: true}), project.activeLayer);
         };


### PR DESCRIPTION
### Description
The pull request adds support for linking multiple images to a single source. This addresses the issue with image data duplication in the href attribute when the same image is used multiple times. The standard functionality for the `exportSVG` function does not change unless the option `linkRaster` is provided.

See [Issue #1993](https://github.com/paperjs/paper.js/issues/1993) for more details

Let me know if you have any feed back, and I can make those changes.

Thanks for all of your work on the project. It has been a great tool that we have used for a long time.

#### Related issues
- Relates to <[Issue #1993](https://github.com/paperjs/paper.js/issues/1993)>

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
