### PR TITLE
Allow paper to be required in node REPL

### DIFF
--- a/src/node/self.js
+++ b/src/node/self.js
@@ -18,7 +18,7 @@ var path = require('path');
 // 'paper-jsdom' or 'paper-jsdom-canvas'), and use this to determine if error
 // exceptions should be thrown or if loading should fail silently.
 var parent = module.parent && module.parent.parent,
-    requireName = parent && path.basename(path.dirname(parent.filename));
+    requireName = parent && parent.filename && path.basename(path.dirname(parent.filename));
 requireName = /^paper/.test(requireName) ? requireName : 'paper';
 
 var jsdom,


### PR DESCRIPTION
Attempting to require paper outside of a file context (i.e the node command line repl) leads to an error loading the path because `parent.filename` is undefined.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
    at __node_internal_captureLargerStackTrace (node:internal/errors:477:5)
    at new NodeError (node:internal/errors:387:5)
    at validateString (node:internal/validators:115:11)
    at Object.dirname (node:path:1276:5)
    at Object.<anonymous> (/.../node_modules/paper/dist/node/self.js:22:48)
```

This adds a short-circuit check which seems to fix the issue.
