### PR TITLE
Pass props to Path constructor in createPath

### DIFF
--- a/src/path/Path.Constructors.js
+++ b/src/path/Path.Constructors.js
@@ -22,11 +22,7 @@ Path.inject({ statics: new function() {
 
     function createPath(segments, closed, args) {
         var props = Base.getNamed(args),
-            path = new Path(props && (
-                props.insert == true ? Item.INSERT
-                : props.insert == false ? Item.NO_INSERT
-                : null
-            ));
+            path = new Path(props);
         path._add(segments);
         // No need to use setter for _closed since _add() called _changed().
         path._closed = closed;


### PR DESCRIPTION
### Description

Described in #2012. 

#### Related issues

- Relates to issue #2012
- Relates to PR #1988

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)