### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -23,7 +23,7 @@ new function() {
         var attrs = new Base(),
             trans = matrix.getTranslation();
         if (coordinates) {
-            // If the item suppports x- and y- coordinates, we're taking out the
+            // If the item supports x- and y- coordinates, we're taking out the
             // translation part of the matrix and move it to x, y attributes, to
             // produce more readable markup, and not have to use center points
             // in rotate(). To do so, SVG requries us to inverse transform the
@@ -354,7 +354,7 @@ new function() {
         var svg = node,
             defs = null;
         if (definitions) {
-            // We can only use svg nodes as defintion containers. Have the loop
+            // We can only use svg nodes as definition containers. Have the loop
             // produce one if it's a single item of another type (when calling
             // #exportSVG() on an item rather than a whole project)
             // jsdom in Node.js uses uppercase values for nodeName...

--- a/src/view/View.js
+++ b/src/view/View.js
@@ -357,7 +357,7 @@ var View = Base.extend(Emitter, /** @lends View# */{
     },
 
     /**
-     * The resoltuion of the underlying canvas / device in pixel per inch (DPI).
+     * The resolution of the underlying canvas / device in pixel per inch (DPI).
      * It is `72` for normal displays, and `144` for high-resolution
      * displays with a pixel-ratio of `2`.
      *
@@ -1040,7 +1040,7 @@ new function() { // Injection scope for event handling on the browser
     var prevFocus,
         tempFocus,
         dragging = false, // mousedown that started on a view.
-        mouseDown = false; // mouesdown anywhere.
+        mouseDown = false; // mousedown anywhere.
 
     function getView(event) {
         // Get the view from the current event target.


### PR DESCRIPTION
There are small typos in:
- src/svg/SvgExport.js
- src/view/View.js

Fixes:
- Should read `supports` rather than `suppports`.
- Should read `resolution` rather than `resoltuion`.
- Should read `mousedown` rather than `mouesdown`.
- Should read `definition` rather than `defintion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md