### PR TITLE
Fix return type JSDoc comment in PathItem.Boolean

### DIFF
--- a/src/path/PathItem.Boolean.js
+++ b/src/path/PathItem.Boolean.js
@@ -1118,7 +1118,8 @@ PathItem.inject(new function() {
          *     contribution
          * @param {Number} [dir=0] the direction in which to determine the
          *     winding contribution, `0`: in x-direction, `1`: in y-direction
-         * @return {Number} the winding number
+         * @return {Object} an object containing the calculated winding number, as
+         *     well as an indication whether the point was situated on the contour
          */
         _getWinding: function(point, dir, closed) {
             return getWinding(point, this.getCurves(), dir, closed);


### PR DESCRIPTION
### Description

This PR fixes an erroneous comment in PathItem.Boolean.js for a function's `@return` JSDoc.

#### Related issues

- [x] New tests added or existing tests modified to cover all changes (N/A)
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)
