### PR TITLE
Issue #1644: Fix performance issue with zooming

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4444,7 +4444,7 @@ new function() { // Injection scope for hit-test functions shared with project
                     || (nativeBlend || normalBlend && opacity < 1)
                         && this._canComposite(),
             pixelRatio = param.pixelRatio || 1,
-            mainCtx, itemOffset, prevOffset;
+            mainCtx;
         if (!direct) {
             // Apply the parent's global matrix to the calculation of correct
             // bounds.
@@ -4455,19 +4455,10 @@ new function() { // Injection scope for hit-test functions shared with project
                 matrices.pop();
                 return;
             }
-            // Store previous offset and save the main context, so we can
-            // draw onto it later.
-            prevOffset = param.offset;
-            // Floor the offset and ceil the size, so we don't cut off any
-            // antialiased pixels when drawing onto the temporary canvas.
-            itemOffset = param.offset = bounds.getTopLeft().floor();
-            // Set ctx to the context of the temporary canvas, so we draw onto
-            // it, instead of the mainCtx.
+
             mainCtx = ctx;
-            ctx = CanvasProvider.getContext(bounds.getSize().ceil().add(1)
-                    .multiply(pixelRatio));
-            if (pixelRatio !== 1)
-                ctx.scale(pixelRatio, pixelRatio);
+            ctx = CanvasProvider.getContext(ctx.canvas.width, ctx.canvas.height);
+            ctx.setTransform(mainCtx.getTransform());
         }
         ctx.save();
         // Get the transformation matrix for non-scaling strokes.
@@ -4490,14 +4481,9 @@ new function() { // Injection scope for hit-test functions shared with project
             ctx.globalAlpha = opacity;
             if (nativeBlend)
                 ctx.globalCompositeOperation = blendMode;
-        } else if (transform) {
-            // Translate the context so the topLeft of the item is at (0, 0)
-            // on the temporary canvas.
-            ctx.translate(-itemOffset.x, -itemOffset.y);
         }
         if (transform) {
-            // Apply viewMatrix when drawing into temporary canvas.
-            (direct ? matrix : viewMatrix).applyToContext(ctx);
+            matrix.applyToContext(ctx);
         }
         if (clip) {
             param.clipItem.draw(ctx, param.extend({ clip: true }));
@@ -4523,14 +4509,9 @@ new function() { // Injection scope for hit-test functions shared with project
         if (!direct) {
             // Use BlendMode.process even for processing normal blendMode with
             // opacity.
-            BlendMode.process(blendMode, ctx, mainCtx, opacity,
-                    // Calculate the pixel offset of the temporary canvas to the
-                    // main canvas. We also need to factor in the pixel-ratio.
-                    itemOffset.subtract(prevOffset).multiply(pixelRatio));
+            BlendMode.process(blendMode, ctx, mainCtx, opacity, new Point(0, 0));
             // Return the temporary context, so it can be reused
             CanvasProvider.release(ctx);
-            // Restore previous offset.
-            param.offset = prevOffset;
         }
     },
 


### PR DESCRIPTION
### Description
Zooming can have poor performance and result in crashing the browser, breaking the canvas, and very high memory usage. 

This is happening because [Item.draw](https://github.com/paperjs/paper.js/blob/92775f5279c05fb7f0a743e9e7fa02cd40ec1e70/src/item/Item.js#L4393-L4535) is requesting a canvas at extreme sizes when using indirect drawing, where something must be drawn to a separate canvas first and then composited back onto the main canvas.

https://github.com/paperjs/paper.js/blob/92775f5279c05fb7f0a743e9e7fa02cd40ec1e70/src/item/Item.js#L4451-L4470

The bounds from `getStrokeBounds` can be upwards of 25,000+ by 25,000+ at high zoom levels, and that is directly used with `CanvasProvider.getContext` to get a canvas of that size. 

https://github.com/paperjs/paper.js/blob/92775f5279c05fb7f0a743e9e7fa02cd40ec1e70/src/canvas/CanvasProvider.js#L45-L46

As soon as the canvas width/height is set, the browser will try to allocate resources for a canvas of that size.

In Chrome you can see the browser memory go from 500mb to 3800mb. The frame time will drop from 1ms to 403ms+. Often this will cause a some kind of crash that will break the canvas. This can cause rendering artifacts and require the page to be reloaded.


This fix will use the current canvas size and transform for the indirect rendering. This will limit the unbounded resource allocation and fix it to the size of the visible canvas. This results in a nearly 400x performance increase at high zoom levels.

#### Related issues
- Relates to #1644 

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`yarn run jshint` passes)

I believe the existing tests should cover the change since its part of the core rendering function. But if its doesn't and this PR gains traction I can add something. 

Let me know if you can think of any problems with this change and I can look into them. I'll also use this in prod for a while and report back after a few weeks.